### PR TITLE
Fix the calculation of probability on CCD (near CCD edge)

### DIFF
--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -257,4 +257,4 @@ def test_get_acq_catalog():
     acqs = get_acq_catalog(21007)
     assert np.all(acqs['id'] == [189417400, 189410928, 189409160, 189417920,
                                  189406216, 189417752, 189015480, 189416328])
-    assert np.all(acqs['halfw'] == [160, 160, 160, 120, 60, 100, 60, 60])
+    assert np.all(acqs['halfw'] == [160, 160, 160, 160, 60, 100, 60, 60])

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -189,7 +189,7 @@ def test_calc_p_brightest_same_bright():
     stars_sp = add_spoiler(stars, acq, dyang=65, dzang=65, dmag=0.0, mag_err=mag_err)
     stars_sp = add_spoiler(stars_sp, acq, dyang=85, dzang=0, dmag=0.0, mag_err=mag_err)
     probs = [calc_p_brightest(acq, box_size, stars_sp, dark_imp, dither=0, bgd=bgd)
-             for box_size in BOX_SIZES]
+             for box_size in CHAR.box_sizes]
 
     #  Box size:                160   140   120    100   80   60  arcsec
     assert np.allclose(probs, [0.25, 0.25, 0.25, 0.3334, 0.5, 1.0], rtol=0, atol=0.01)

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -9,7 +9,7 @@ from chandra_aca.transform import mag_to_count_rate, yagzag_to_pixels
 from ..acq import (get_p_man_err, bin2x2, CHAR,
                    get_imposter_stars, get_stars, get_acq_candidates,
                    get_image_props, calc_p_brightest,
-                   calc_p_in_box,
+                   calc_p_on_ccd,
                    get_acq_catalog,
                    )
 
@@ -211,24 +211,29 @@ def test_calc_p_brightest_1mag_brighter():
     assert np.allclose(probs, [0.0, 1.0], rtol=0, atol=0.001)
 
 
-def test_calc_p_in_box():
+def test_calc_p_on_ccd():
+    # These lines mimic the code in calc_p_on_ccd() which requires that
+    # track readout box is fully within the usable part of CCD.
+    max_ccd_row = CHAR.max_ccd_row - 5
+    max_ccd_col = CHAR.max_ccd_col - 4
+
     # Halfway off in both row and col, (1/4 of area remaining)
-    p_in_box = calc_p_in_box(CHAR.max_ccd_row, CHAR.max_ccd_col, 60)
+    p_in_box = calc_p_on_ccd(max_ccd_row, max_ccd_col, 60)
     assert np.allclose(p_in_box, 0.25)
 
-    p_in_box = calc_p_in_box(CHAR.max_ccd_row, CHAR.max_ccd_col, 120)
+    p_in_box = calc_p_on_ccd(max_ccd_row, max_ccd_col, 120)
     assert np.allclose(p_in_box, 0.25)
 
     # 3 of 8 pixels off in row (5/8 of area remaining)
-    p_in_box = calc_p_in_box(CHAR.max_ccd_row - 1, 0, 20)
+    p_in_box = calc_p_on_ccd(max_ccd_row - 1, 0, 20)
     assert np.allclose(p_in_box, 0.625)
 
     # Same but for col
-    p_in_box = calc_p_in_box(0, CHAR.max_ccd_col - 1, 20)
+    p_in_box = calc_p_on_ccd(0, max_ccd_col - 1, 20)
     assert np.allclose(p_in_box, 0.625)
 
     # Same but for a negative col number
-    p_in_box = calc_p_in_box(0, -(CHAR.max_ccd_col - 1), 20)
+    p_in_box = calc_p_on_ccd(0, -(max_ccd_col - 1), 20)
     assert np.allclose(p_in_box, 0.625)
 
 

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -6,10 +6,10 @@ import numpy as np
 from chandra_aca.aca_image import AcaPsfLibrary
 from chandra_aca.transform import mag_to_count_rate, yagzag_to_pixels
 
-from ..acq import (get_p_man_err, P_NORMAL, P_BIG, P_ANOM, bin2x2,
+from ..acq import (get_p_man_err, bin2x2, CHAR,
                    get_imposter_stars, get_stars, get_acq_candidates,
-                   get_image_props, calc_p_brightest, BOX_SIZES,
-                   calc_p_in_box, MAX_CCD_ROW, MAX_CCD_COL,
+                   get_image_props, calc_p_brightest,
+                   calc_p_in_box,
                    get_acq_catalog,
                    )
 
@@ -213,20 +213,23 @@ def test_calc_p_brightest_1mag_brighter():
 
 def test_calc_p_in_box():
     # Halfway off in both row and col, (1/4 of area remaining)
-    p_in_boxes = calc_p_in_box(MAX_CCD_ROW, MAX_CCD_COL, [60, 120])
-    assert np.allclose(p_in_boxes, [0.25, 0.25])
+    p_in_box = calc_p_in_box(CHAR.max_ccd_row, CHAR.max_ccd_col, 60)
+    assert np.allclose(p_in_box, 0.25)
+
+    p_in_box = calc_p_in_box(CHAR.max_ccd_row, CHAR.max_ccd_col, 120)
+    assert np.allclose(p_in_box, 0.25)
 
     # 3 of 8 pixels off in row (5/8 of area remaining)
-    p_in_boxes = calc_p_in_box(MAX_CCD_ROW - 1, 0, [20])
-    assert np.allclose(p_in_boxes, [0.625])
+    p_in_box = calc_p_in_box(CHAR.max_ccd_row - 1, 0, 20)
+    assert np.allclose(p_in_box, 0.625)
 
     # Same but for col
-    p_in_boxes = calc_p_in_box(0, MAX_CCD_COL - 1, [20])
-    assert np.allclose(p_in_boxes, [0.625])
+    p_in_box = calc_p_in_box(0, CHAR.max_ccd_col - 1, 20)
+    assert np.allclose(p_in_box, 0.625)
 
     # Same but for a negative col number
-    p_in_boxes = calc_p_in_box(0, -(MAX_CCD_COL - 1), [20])
-    assert np.allclose(p_in_boxes, [0.625])
+    p_in_box = calc_p_in_box(0, -(CHAR.max_ccd_col - 1), 20)
+    assert np.allclose(p_in_box, 0.625)
 
 
 def test_get_acq_catalog():


### PR DESCRIPTION
As first seen in #15 and noted in other discussions, the calculation in `calc_p_in_box` was conceptually wrong by using the search box size instead of the maneuver error + dither size.  This fixes that.  Unfortunately there is no star catalog regression test that highlights this (and for silly technical reasons it ended up being a pain to inject one into the history), so I just present the catalog diffs for 21122.  This shows the expected change of two bright stars that had their acq search boxes reduced (incorrectly) because of proximity to the CCD edge.

This does pass the `test_calc_p_on_ccd` test, but fails others (to be fixed).

**master**
```
In [2]: acqs = get_acq_catalog(21122)
In [3]: acqs['id', 'row', 'col', 'mag', 'halfw']
Out[3]: 
<AcqTable length=8>
    id      row     col     mag   halfw
  int32   float64 float64 float32 int64
--------- ------- ------- ------- -----
198708304 -134.14 -141.41    8.16   160
198705968 -129.15  179.35    9.53   160
198707824 -338.03 -132.92    9.32   160
198713024 -477.15 -249.63    7.58   160
198837864  157.15  162.82    9.58   160
198705568 -486.11  -42.52    9.70   160
267653496  490.37  -40.96    9.06    80
198708256 -357.18  502.34    8.11    60
```
**With this PR**
```
In [4]: acqs['id', 'row', 'col', 'mag', 'halfw']
Out[4]: 
<AcqTable length=8>
    id      row     col     mag   halfw
  int32   float64 float64 float32 int64
--------- ------- ------- ------- -----
198708304 -134.14 -141.41    8.16   160
198705968 -129.15  179.35    9.53   160
198707824 -338.03 -132.92    9.32   160
198837864  157.15  162.82    9.58   160
198713024 -477.15 -249.63    7.58   160
198705568 -486.11  -42.52    9.70   160
267653496  490.37  -40.96    9.06   160
198708256 -357.18  502.34    8.11   160
```