### PR TITLE
Improved box size optimization strategy

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -942,13 +942,25 @@ def optimize_acq_halfw(acqs, idx, p_safe, verbose=False):
     """
     acq = acqs[idx]
     orig_halfw = acq['halfw']
+    orig_p_acq = acq['p_acq_marg'][acq['halfw']]
+
     acqs.log('Optimizing halfw for idx={} id={}'.format(idx, acq['id']), id=acq['id'])
 
     # Compute p_safe for each possible halfw for the current star
     p_safes = []
     for box_size in CHAR.box_sizes:
-        acq['halfw'] = box_size
-        p_safes.append(calc_p_safe(acqs))
+        new_p_acq = acq['p_acq_marg'][box_size]
+        # Do not reduce marginalized p_acq to below 0.1.  It can happen that p_safe
+        # goes down very slightly with an increase in box size from the original,
+        # and then the box size gets stuck there because of the deadband for later
+        # reducing box size.
+        if new_p_acq < 0.1 and new_p_acq < orig_p_acq:
+            acqs.log(f'Skipping halfw {box_size}: new marg p_acq < 0.1 and new < orig'
+                     ' ({new_p_acq:.3f} < {orig_p_acq:.3f})')
+            p_safes.append(p_safe)
+        else:
+            acq['halfw'] = box_size
+            p_safes.append(calc_p_safe(acqs))
 
     # Find best p_safe
     min_idx = np.argmin(p_safes)

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -915,11 +915,14 @@ def calc_p_safe(acqs, verbose=False):
     p_no_safe = 1.0
 
     for man_err, p_man_err in zip(CHAR.man_errs, acqs.meta['p_man_errs']):
+        if p_man_err == 0.0:
+            continue
+
         p_acqs = [acq['p_acqs'][acq['halfw'], man_err] for acq in acqs]
 
         p_n, p_n_cum = prob_n_acq(p_acqs)
         if verbose:
-            acqs.log('man_err = {}'.format(man_err))
+            acqs.log('man_err = {}, p_man_err = {}'.format(man_err, p_man_err))
             acqs.log('p_acqs =' + ' '.join(['{:.3f}'.format(val) for val in p_acqs]))
             acqs.log('log10(p 1_or_fewer) = {:.2f}'.format(np.log10(p_n_cum[1])))
         p_01 = p_n_cum[1]  # 1 or fewer => p_fail at this man_err

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -318,6 +318,32 @@ def test_get_acq_catalog_21007():
     assert repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines() == exp
 
 
+def test_box_strategy_20603():
+    """Test for PR #32 that doesn't allow p_acq to be reduced below 0.1.
+    The idx=8 (mag=10.50) star was previously selected with 160 arsec box.
+    """
+    acqs = get_acq_catalog(20603)
+    exp = ['<AcqTable length=13>',
+           ' idx  slot     id      yang     zang   halfw   mag    p_acq ',
+           'int64 str3   int32   float64  float64  int64 float32 float64',
+           '----- ---- --------- -------- -------- ----- ------- -------',
+           '    0    0  40113544   102.76  1133.36   160    7.91   0.985',
+           '    1    1 116791824   622.00  -953.60   160    9.01   0.958',
+           '    2    2 116923496 -1337.79  1049.26   120    9.14   0.970',
+           '    3    3  40114416   394.23  1204.43   160    9.78   0.885',
+           '    4    4  40112304 -1644.34  2032.46    80    9.79   0.932',
+           '    5    5 116923528 -2418.66  1088.42   160    9.84   0.593',
+           '    6    6 116791744   985.39 -1210.18    60   10.29   0.501',
+           '    7  ...  40108048     2.21  1619.18   120   10.46   0.023',
+           '    8    7 116785920  -673.93 -1575.88    60   10.50   0.136',
+           '    9  ... 116791664  2307.25 -1504.54   120   10.74   0.000',
+           '   10  ... 116792320   941.59 -1784.09   120   10.83   0.000',
+           '   11  ... 116923744  -853.18   937.73   120   10.84   0.000',
+           '   12  ... 116918232 -2074.90 -1769.95   120   10.96   0.000']
+
+    assert repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines() == exp
+
+
 def test_to_from_yaml():
     acqs = get_acq_catalog(21007)  # Fast because of caching
 


### PR DESCRIPTION
Do not reduce marginalized p_acq for a star to below 0.1. 

Obsid 20603 was used as the poster child (see #15) with a 10.503 mag star that gets a 140" box despite 4 other 160s.  This star was the first to be optimized before there were other 160" boxes in the catalog.  At that point it was very marginally better for p_safe to increase the faint star box size.  Then later the other stars got bigger boxes and when trying to reduce back down to 60" the improvement was not enough to meet the 90% deadband requirement.
```
optimize_acq_halfw | Optimizing halfw for idx=7 id=116785920
optimize_acq_halfw | p_safes=-3.76 (160"), -3.76 (140"), -3.76 (120"), -3.76 (100"), -3.76 (80"), -3.76 (60")
optimize_acq_halfw | min_p_safe=-3.76 p_safe=-3.76 min_halfw=140 orig_halfw=60 improved=True
optimize_acq_halfw | Update acq idx=7 halfw from 60 to 140

optimize_acq_halfw | Optimizing halfw for idx=7 id=116785920
optimize_acq_halfw | p_safes=-4.44 (160"), -4.44 (140"), -4.44 (120"), -4.45 (100"), -4.45 (80"), -4.47 (60")
optimize_acq_halfw | min_p_safe=-4.47 p_safe=-4.44 min_halfw=60 orig_halfw=140 improved=False

```

The upshot is to just not change the box size in a way that reduces the p_acq to below 0.1.  In the case of 20603 it was going to 0.005 which is just useless.
