### PR TITLE
Use binned 2x2 pixel region to look for hot pixels that might spoil a guide star

### DIFF
--- a/proseco/gui.py
+++ b/proseco/gui.py
@@ -156,10 +156,14 @@ def check_imposters(stars, ok, dark, dither, opt):
         rplus = int(np.ceil(cand['row'] + row_extent + 1))
         cminus = int(np.floor(cand['col'] - col_extent))
         cplus = int(np.ceil(cand['col'] + col_extent + 1))
-        pix = dark.aca[rminus:rplus, cminus:cplus]
-        cand_counts = chandra_aca.mag_to_count_rate(cand['MAG_ACA'])
+        pix = np.array(dark.aca[rminus:rplus, cminus:cplus])
+        pixmax = max(np.max(bin2x2(pix)),
+                     np.max(bin2x2(pix[1:-1])),
+                     np.max(bin2x2(pix[:,1:-1])),
+                     np.max(bin2x2(pix[1:-1,1:-1])))
+        pixmax_mag = chandra_aca.count_rate_to_mag(pixmax)
         # Check that the max 2x2 region is less than the threshold for this stage
-        if np.max(bin2x2(pix)) > (cand_counts * opt['Imposter']['Thresh']):
+        if pixmax_mag < (cand['MAG_ACA'] + opt['Imposter']['Thresh']):
             imp[stars['AGASC_ID'] == cand['AGASC_ID']] = True
     return imp
 

--- a/proseco/gui_char.py
+++ b/proseco/gui_char.py
@@ -71,7 +71,7 @@ CHAR = { "Stars": {
                     "SigErrMultiplier": 3,
                     },
                 "Imposter": {
-                    "Thresh": .025,
+                    "Thresh": .05,
                     },
                 },
             {
@@ -98,7 +98,7 @@ CHAR = { "Stars": {
                     "SigErrMultiplier": 2,
                     },
                 "Imposter": {
-                    "Thresh": .05,
+                    "Thresh": .075,
                     },
                 },
             {
@@ -125,7 +125,7 @@ CHAR = { "Stars": {
                     "SigErrMultiplier": 1,
                     },
                 "Imposter": {
-                    "Thresh": .05,
+                    "Thresh": .075,
                     },
                 },
             {
@@ -152,7 +152,7 @@ CHAR = { "Stars": {
                     "SigErrMultiplier": 0,
                     },
                 "Imposter": {
-                    "Thresh": .075,
+                    "Thresh": .10,
                     },
                 },
             {

--- a/proseco/gui_char.py
+++ b/proseco/gui_char.py
@@ -71,7 +71,7 @@ CHAR = { "Stars": {
                     "SigErrMultiplier": 3,
                     },
                 "Imposter": {
-                    "Thresh": .05,
+                    "Thresh": 3.5,
                     },
                 },
             {
@@ -98,7 +98,7 @@ CHAR = { "Stars": {
                     "SigErrMultiplier": 2,
                     },
                 "Imposter": {
-                    "Thresh": .075,
+                    "Thresh": 3.0,
                     },
                 },
             {
@@ -125,7 +125,7 @@ CHAR = { "Stars": {
                     "SigErrMultiplier": 1,
                     },
                 "Imposter": {
-                    "Thresh": .075,
+                    "Thresh": 3.0,
                     },
                 },
             {
@@ -152,7 +152,7 @@ CHAR = { "Stars": {
                     "SigErrMultiplier": 0,
                     },
                 "Imposter": {
-                    "Thresh": .10,
+                    "Thresh": 2.5,
                     },
                 },
             {
@@ -179,7 +179,7 @@ CHAR = { "Stars": {
                     "SigErrMultiplier": 0,
                     },
                 "Imposter": {
-                    "Thresh": .15,
+                    "Thresh": 1.75,
                     },
                 }
             ],

--- a/proseco/gui_char.py
+++ b/proseco/gui_char.py
@@ -28,21 +28,11 @@ CHAR = { "Stars": {
                     "Pos": [3,7]
                     }
                 },
-            "FOV": {
-                "YArcSecLim": [-2410,2473],
-                "ZArcSecLim": [-2504,2450]
-                },
             "Body": {
                 "Column": {
                     "MagDiff": 4.5,
                     "Separation": 10,
                     },
-                "Pixels": {
-                    "ZPixLim": [-512.5,511.5],
-                    "YPixLim": [-512.5,511.5],
-                    "Center": [-0.5,-0.5],
-                    "EdgeBuffer": 5,
-                    }
                 },
             "Select": {
                 "NMaxSelect": 8,

--- a/proseco/tests/test_gui.py
+++ b/proseco/tests/test_gui.py
@@ -78,5 +78,5 @@ def test_big_dither():
     date = '2018:233'
     selected = select_guide_stars(311.208763, -31.270875, 308.957038,
                                   dither=(64, 8), date=date)
-    expected = [977409032,  977414712, 977416336, 977282416, 977405808]
+    expected = [977409032,  977414712, 977416336, 977405808, 977410960]
     assert selected['AGASC_ID'].tolist() == expected

--- a/proseco/tests/test_gui.py
+++ b/proseco/tests/test_gui.py
@@ -78,5 +78,5 @@ def test_big_dither():
     date = '2018:233'
     selected = select_guide_stars(311.208763, -31.270875, 308.957038,
                                   dither=(64, 8), date=date)
-    expected = [977409032,  977414712, 977416336, 977405808, 977410960]
+    expected = [977409032,  977414712, 977416336, 977282416, 977405808]
     assert selected['AGASC_ID'].tolist() == expected


### PR DESCRIPTION
Instead of using the max pixel value in the pixel region for the guide star, use the max of the 2x2 sum in the region.