### PR TITLE
Major refactor

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -383,15 +383,6 @@ def calc_p_brightest(acq, box_size, stars, dark, man_err=0,
     return prob
 
 
-def broadcast_arrays(*args):
-    is_scalar = all(np.array(arg).ndim == 0 for arg in args)
-    args = np.atleast_1d(*args)
-    if not isinstance(args, list):
-        args = [args]
-    outs = [is_scalar] + np.broadcast_arrays(*args)
-    return outs
-
-
 def calc_p_on_ccd(row, col, box_size):
     """
     Calculate the probability that star and initial tracked readout box

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -6,187 +6,17 @@ Get a catalog of acquisition stars using the algorithm described in
 https://docs.google.com/presentation/d/1VtFKAW9he2vWIQAnb6unpK4u1bVAVziIdX9TnqRS3a8
 """
 
-import os
-import inspect
-import time
-from copy import copy
-
 import numpy as np
-import yaml
 from scipy import ndimage, stats
-from scipy.interpolate import interp1d
-from astropy.table import Table, Column
+from astropy.table import Table
 
 from chandra_aca.star_probs import acq_success_prob, prob_n_acq
-from chandra_aca.transform import (yagzag_to_pixels, pixels_to_yagzag,
+from chandra_aca.transform import (pixels_to_yagzag,
                                    mag_to_count_rate, count_rate_to_mag)
 from mica.archive.aca_dark.dark_cal import get_dark_cal_image
-from Ska.quatutil import radec2yagzag
-from agasc import get_agasc_cone
-from Quaternion import Quat
 
 from . import characteristics as CHAR
-
-
-def to_python(val):
-    try:
-        val = val.tolist()
-    except AttributeError:
-        pass
-    return val
-
-
-class AcqTable(Table):
-    def __init__(self, *args, print_log=False, **kwargs):
-        super(AcqTable, self).__init__(*args, **kwargs)
-        self.log_info = {}
-        self.log_info['events'] = []
-        self.log_info['time0'] = time.time()
-        self.print_log = print_log
-
-        # Make printed table look nicer.  This is defined in advance
-        # and will be applied the first time the table is represented.
-        self._default_formats = {'p_acq': '.3f'}
-        for name in ('yang', 'zang', 'row', 'col', 'mag', 'mag_err', 'color'):
-            self._default_formats[name] = '.2f'
-        for name in ('ra', 'dec', 'RA_PMCORR', 'DEC_PMCORR'):
-            self._default_formats[name] = '.6f'
-
-    def log(self, data, **kwargs):
-        # Name of calling functions, starting from top (outermost) and
-        # ending with function that called log()
-        func = inspect.currentframe().f_back.f_code.co_name
-
-        # Possible extension later to include calling context, but this
-        # currently includes a whole bunch more, need to filter to just
-        # this module.
-        # framerecs = inspect.stack()[1:-1]
-        # funcs = [framerec[3] for framerec in reversed(framerecs)]
-        # func = funcs[-1]
-
-        dt = time.time() - self.log_info['time0']
-        kwargs = {key: to_python(val) for key, val in kwargs.items()}
-        event = dict(dt=round(dt, 4),
-                     func=func,
-                     # funcs=funcs,
-                     data=data,
-                     **kwargs)
-        self.log_info['events'].append(event)
-        if self.print_log:
-            data_str = ' ' * event.get('level', 0) * 4 + str(event['data'])
-            print(f'{dt:7.3f} {func:20s}: {data_str}')
-
-    def _base_repr_(self, *args, **kwargs):
-        names = [name for name in self.colnames
-                 if self[name].dtype.kind != 'O']
-
-        # Apply default formats to applicable columns and delete
-        # that default format so it doesn't get set again next time.
-        for name in list(self._default_formats.keys()):
-            if name in names:
-                self[name].format = self._default_formats.pop(name)
-
-        return super(AcqTable, self[names])._base_repr_(*args, **kwargs)
-
-    def to_yaml(self, rootdir=None):
-        """
-        Serialize table as YAML and return string.  If ``rootdir`` is set then
-        the table YAML is output to ``<rootdir>/obs<obsid>/acqs.yaml``.
-        """
-        out = {}
-        exclude = ('stars', 'cand_acqs', 'dark', 'bad_stars')
-        for par in self.meta:
-            if par not in exclude:
-                out[par] = to_python(self.meta[par])
-        out['acqs'] = self.to_struct()
-        out['cand_acqs'] = self.meta['cand_acqs'].to_struct()
-        out['log_info'] = self.log_info
-
-        yml = yaml.dump(out)
-
-        if rootdir is not None:
-            outdir = os.path.join(rootdir, 'obs{:05}'.format(self.meta['obsid']))
-            if not os.path.exists(outdir):
-                os.mkdir(outdir)
-            outfile = os.path.join(outdir, 'acqs.yaml')
-            with open(outfile, 'w') as fh:
-                fh.write(yml)
-
-        return yml
-
-    @classmethod
-    def from_yaml(cls, yaml_str):
-        """
-        Construct table from YAML string
-        """
-        obj = yaml.load(yaml_str)
-        acqs = cls.from_struct(obj.pop('acqs'))
-        acqs.meta['cand_acqs'] = cls.from_struct(obj.pop('cand_acqs'))
-        acqs.log_info.update(obj.pop('log_info'))
-
-        for par in obj:
-            acqs.meta[par] = copy(obj[par])
-        return acqs
-
-    def to_struct(self):
-        """Turn table into a dict structure with keys:
-
-        - names: column names in order
-        - dtype: column dtypes as strings
-        - rows: list of dict with row values
-
-        This takes pains to remove any numpy objects so the YAML serialization
-        is tidy (pure-Python only).
-        """
-        rows = []
-        colnames = self.colnames
-        dtypes = [col.dtype.str for col in self.itercols()]
-        out = {'names': colnames, 'dtype': dtypes}
-
-        for row in self:
-            outrow = {}
-            for name in colnames:
-                val = row[name]
-                if isinstance(val, np.ndarray) and val.dtype.names:
-                    val = Table(val)
-
-                if isinstance(val, Table):
-                    val = AcqTable.to_struct(val)
-
-                elif isinstance(val, dict):
-                    new_val = {}
-                    for key, item in val.items():
-                        if isinstance(key, tuple):
-                            key = tuple(to_python(k) for k in key)
-                        else:
-                            key = to_python(key)
-                        item = to_python(item)
-                        new_val[key] = item
-                    val = new_val
-
-                else:
-                    val = to_python(val)
-
-                outrow[name] = val
-            rows.append(outrow)
-
-        # Only include rows=[..] kwarg if there are rows.  Table initializer is unhappy
-        # with a zero-length list for rows, but is OK with just names=[..] dtype=[..].
-        if rows:
-            out['rows'] = rows
-
-        return out
-
-    @classmethod
-    def from_struct(cls, struct):
-        out = cls(**struct)
-        for name in out.colnames:
-            col = out[name]
-            if col.dtype.kind == 'O':
-                for idx, val in enumerate(col):
-                    if isinstance(val, dict) and 'dtype' in val.keys():
-                        col[idx] = Table(**val)
-        return out
+from .core import AcqTable, get_mag_std, get_stars
 
 
 def get_p_man_err(man_err, man_angle):
@@ -203,105 +33,6 @@ def get_p_man_err(man_err, man_angle):
         raise ValueError('man_err must be <= {}'.format(pme['man_err_hi']))
 
     return pme[name][man_err_idx]
-
-
-# AGASC columns not needed (at this moment) for acq star selection.
-# Change as needed.
-AGASC_COLS_DROP = [
-    'RA',
-    'DEC',
-    'POS_CATID',
-    'EPOCH',
-    'PM_CATID',
-    'PLX',
-    'PLX_ERR',
-    'PLX_CATID',
-    'MAG',
-    'MAG_ERR',
-    'MAG_BAND',
-    'MAG_CATID',
-    'C1_CATID',
-    'COLOR2',
-    'COLOR2_ERR',
-    'C2_CATID',
-    'RSV1',
-    'RSV2',
-    'RSV3',
-    'VAR_CATID',
-    'ACQQ1',
-    'ACQQ2',
-    'ACQQ3',
-    'ACQQ4',
-    'ACQQ5',
-    'ACQQ6',
-    'XREF_ID1',
-    'XREF_ID2',
-    'XREF_ID3',
-    'XREF_ID4',
-    'XREF_ID5',
-    'RSV4',
-    'RSV5',
-    'RSV6',
-]
-
-# Define a function that returns the observed standard deviation in ACA mag
-# as a function of catalog mag.  This is about the std-dev for samples
-# within an observation, NOT the error on the catalog mag (which is about
-# the error on mean of the sample, not the std-dev of the sample).
-#
-# See skanb/star_selection/star-mag-std-dev.ipynb for the source of numbers.
-#
-# Note that get_mag_std is a function that is called with get_mag_std(mag_aca).
-get_mag_std = interp1d(x=[-10, 6.7, 7.3, 7.8, 8.3, 8.8, 9.2, 9.7, 10.1, 11, 20],  # mag
-                       y=[0.015, 0.015, 0.022, 0.029, 0.038, 0.055, 0.077,
-                          0.109, 0.141, 0.23, 1.0],  # std-dev
-                       kind='linear')
-
-
-def get_stars(acqs, att, date=None, radius=1.2):
-    """
-    Get AGASC stars in the ACA FOV.  This uses the mini-AGASC, so only stars
-    within 3-sigma of 11.5 mag.  TO DO: maybe use the full AGASC, for faint
-    candidate acq stars with large uncertainty.
-    """
-    q_att = Quat(att)
-    acqs.log('Getting stars at ra={:.5f} dec={:.4f}'
-             .format(q_att.ra, q_att.dec))
-    stars = get_agasc_cone(q_att.ra, q_att.dec, radius=radius, date=date)
-    acqs.log('Got {} stars'.format(len(stars)), level=1)
-    yag, zag = radec2yagzag(stars['RA_PMCORR'], stars['DEC_PMCORR'], q_att)
-    yag *= 3600
-    zag *= 3600
-    row, col = yagzag_to_pixels(yag, zag, allow_bad=True, pix_zero_loc='edge')
-
-    stars.remove_columns(AGASC_COLS_DROP)
-
-    stars.rename_column('AGASC_ID', 'id')
-    stars.add_column(Column(stars['RA_PMCORR'], name='ra'), index=1)
-    stars.add_column(Column(stars['DEC_PMCORR'], name='dec'), index=2)
-    stars.add_column(Column(yag, name='yang'), index=3)
-    stars.add_column(Column(zag, name='zang'), index=4)
-    stars.add_column(Column(row, name='row'), index=5)
-    stars.add_column(Column(col, name='col'), index=6)
-
-    stars.add_column(Column(stars['MAG_ACA'], name='mag'), index=7)  # For convenience
-
-    # Mag_err column is the RSS of the catalog mag err (i.e. systematic error in
-    # the true star mag) and the sample uncertainty in the ACA readout mag
-    # for a star with mag=MAG_ACA.  The latter typically dominates above 9th mag.
-    mag_aca_err = stars['MAG_ACA_ERR'] * 0.01
-    mag_std_dev = get_mag_std(stars['MAG_ACA'])
-    mag_err = np.sqrt(mag_aca_err ** 2 + mag_std_dev ** 2)
-    stars.add_column(Column(mag_err, name='mag_err'), index=8)
-
-    # Filter stars in or near ACA FOV
-    rcmax = 512.0 + 200 / 5  # 200 arcsec padding around CCD edge
-    ok = (row > -rcmax) & (row < rcmax) & (col > -rcmax) & (col < rcmax)
-    stars = stars[ok]
-
-    acqs.log('Finished star processing', level=1)
-
-    return stars
 
 
 def get_acq_candidates(acqs, stars, max_candidates=20):
@@ -1141,7 +872,7 @@ def get_acq_catalog(obsid=0, att=None,
     acqs.meta['p_man_errs'] = np.array([get_p_man_err(man_err, acqs.meta['man_angle'])
                                         for man_err in CHAR.man_errs])
 
-    stars = get_stars(acqs, att, date=date)
+    stars = get_stars(att, date=date, logger=acqs.log)
     cand_acqs, bad_stars = get_acq_candidates(acqs, stars)
 
     # Fill in the entire acq['p_acqs'] table (which is actual a dict of keyed by

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -11,12 +11,12 @@ from scipy import ndimage, stats
 from astropy.table import Table
 
 from chandra_aca.star_probs import acq_success_prob, prob_n_acq
-from chandra_aca.transform import (pixels_to_yagzag,
-                                   mag_to_count_rate, count_rate_to_mag)
+from chandra_aca.transform import (pixels_to_yagzag, mag_to_count_rate)
 from mica.archive.aca_dark.dark_cal import get_dark_cal_image
 
 from . import characteristics as CHAR
-from .core import AcqTable, get_mag_std, get_stars
+from .core import (get_mag_std, get_stars, ACACatalogTable, bin2x2,
+                   get_image_props, pea_reject_image)
 
 
 def get_p_man_err(man_err, man_angle):
@@ -33,6 +33,10 @@ def get_p_man_err(man_err, man_angle):
         raise ValueError('man_err must be <= {}'.format(pme['man_err_hi']))
 
     return pme[name][man_err_idx]
+
+
+class AcqTable(ACACatalogTable):
+    pass
 
 
 def get_acq_candidates(acqs, stars, max_candidates=20):
@@ -154,75 +158,6 @@ def get_spoiler_stars(stars, acq, box_size):
     spoilers.sort(order=['mag'])
 
     return spoilers
-
-
-def bin2x2(arr):
-    """Bin 2-d ``arr`` in 2x2 blocks.  Requires that ``arr`` has even shape sizes"""
-    shape = (arr.shape[0] // 2, 2, arr.shape[1] // 2, 2)
-    return arr.reshape(shape).sum(-1).sum(1)
-
-
-RC_6x6 = np.array([10, 11, 12, 13,
-                   17, 18, 19, 20, 21, 22,
-                   25, 26, 27, 28, 29, 30,
-                   33, 34, 35, 36, 37, 38,
-                   41, 42, 43, 44, 45, 46,
-                   50, 51, 52, 53],
-                  dtype=np.int64)
-
-ROW_6x6 = np.array([1, 1, 1, 1,
-                    2, 2, 2, 2, 2, 2,
-                    3, 3, 3, 3, 3, 3,
-                    4, 4, 4, 4, 4, 4,
-                    5, 5, 5, 5, 5, 5,
-                    6, 6, 6, 6],
-                   dtype=np.float64) + 0.5
-
-COL_6x6 = np.array([2, 3, 4, 5,
-                    1, 2, 3, 4, 5, 6,
-                    1, 2, 3, 4, 5, 6,
-                    1, 2, 3, 4, 5, 6,
-                    1, 2, 3, 4, 5, 6,
-                    2, 3, 4, 5],
-                   dtype=np.float64) + 0.5
-
-
-def get_image_props(ccd_img, c_row, c_col, bgd=None):
-    """
-    Do a pseudo-read and compute the background-subtracted magnitude
-    of the image.  Returns the 8x8 image and mag.
-
-    :param ccd_image: full-frame CCD image (e.g. dark current, with or without stars).
-    :param c_row: int row at center (readout row-4 to row+4)
-    :param c_col: int col at center
-    :param bgd: background to subtract at each pixel.  If None then compute flight bgd.
-
-    :returns: 8x8 image (ndarray), image mag
-    """
-    img = ccd_img[c_row - 4:c_row + 4, c_col - 4:c_col + 4]
-
-    if bgd is None:
-        raise NotImplementedError('no calc_flight_background here')
-        # bgd = calc_flight_background(img)  # currently not defined
-
-    img = img - bgd
-    img_6x6 = img.flatten()[RC_6x6]
-    img_sum = np.sum(img_6x6)
-    r = np.sum(img_6x6 * ROW_6x6) / img_sum
-    c = np.sum(img_6x6 * COL_6x6) / img_sum
-    row = r + c_row - 4
-    col = c + c_col - 4
-    mag = count_rate_to_mag(img_sum)
-
-    return img, img_sum, mag, row, col
-
-
-def pea_reject_image(img):
-    """
-    Check if PEA would reject image (too narrow, too peaky, etc)
-    """
-    # To be implemented
-    return False
 
 
 def get_imposter_stars(dark, star_row, star_col, thresh=None,

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -54,7 +54,6 @@ class ACACatalogTable(Table):
         kwargs = {key: to_python(val) for key, val in kwargs.items()}
         event = dict(dt=round(dt, 4),
                      func=func,
-                     # funcs=funcs,
                      data=data,
                      **kwargs)
         self.log_info['events'].append(event)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -1,0 +1,277 @@
+import os
+import inspect
+import time
+from copy import copy
+
+import numpy as np
+import yaml
+from scipy.interpolate import interp1d
+from astropy.table import Table, Column
+
+from chandra_aca.transform import yagzag_to_pixels
+from Ska.quatutil import radec2yagzag
+from agasc import get_agasc_cone
+from Quaternion import Quat
+
+
+def to_python(val):
+    try:
+        val = val.tolist()
+    except AttributeError:
+        pass
+    return val
+
+
+class AcqTable(Table):
+    def __init__(self, *args, print_log=False, **kwargs):
+        super(AcqTable, self).__init__(*args, **kwargs)
+        self.log_info = {}
+        self.log_info['events'] = []
+        self.log_info['time0'] = time.time()
+        self.print_log = print_log
+
+        # Make printed table look nicer.  This is defined in advance
+        # and will be applied the first time the table is represented.
+        self._default_formats = {'p_acq': '.3f'}
+        for name in ('yang', 'zang', 'row', 'col', 'mag', 'mag_err', 'color'):
+            self._default_formats[name] = '.2f'
+        for name in ('ra', 'dec', 'RA_PMCORR', 'DEC_PMCORR'):
+            self._default_formats[name] = '.6f'
+
+    def log(self, data, **kwargs):
+        # Name of calling functions, starting from top (outermost) and
+        # ending with function that called log()
+        func = inspect.currentframe().f_back.f_code.co_name
+
+        # Possible extension later to include calling context, but this
+        # currently includes a whole bunch more, need to filter to just
+        # this module.
+        # framerecs = inspect.stack()[1:-1]
+        # funcs = [framerec[3] for framerec in reversed(framerecs)]
+        # func = funcs[-1]
+
+        dt = time.time() - self.log_info['time0']
+        kwargs = {key: to_python(val) for key, val in kwargs.items()}
+        event = dict(dt=round(dt, 4),
+                     func=func,
+                     # funcs=funcs,
+                     data=data,
+                     **kwargs)
+        self.log_info['events'].append(event)
+        if self.print_log:
+            data_str = ' ' * event.get('level', 0) * 4 + str(event['data'])
+            print(f'{dt:7.3f} {func:20s}: {data_str}')
+
+    def _base_repr_(self, *args, **kwargs):
+        names = [name for name in self.colnames
+                 if self[name].dtype.kind != 'O']
+
+        # Apply default formats to applicable columns and delete
+        # that default format so it doesn't get set again next time.
+        for name in list(self._default_formats.keys()):
+            if name in names:
+                self[name].format = self._default_formats.pop(name)
+
+        return super(AcqTable, self[names])._base_repr_(*args, **kwargs)
+
+    def to_yaml(self, rootdir=None):
+        """
+        Serialize table as YAML and return string.  If ``rootdir`` is set then
+        the table YAML is output to ``<rootdir>/obs<obsid>/acqs.yaml``.
+        """
+        out = {}
+        exclude = ('stars', 'cand_acqs', 'dark', 'bad_stars')
+        for par in self.meta:
+            if par not in exclude:
+                out[par] = to_python(self.meta[par])
+        out['acqs'] = self.to_struct()
+        out['cand_acqs'] = self.meta['cand_acqs'].to_struct()
+        out['log_info'] = self.log_info
+
+        yml = yaml.dump(out)
+
+        if rootdir is not None:
+            outdir = os.path.join(rootdir, 'obs{:05}'.format(self.meta['obsid']))
+            if not os.path.exists(outdir):
+                os.mkdir(outdir)
+            outfile = os.path.join(outdir, 'acqs.yaml')
+            with open(outfile, 'w') as fh:
+                fh.write(yml)
+
+        return yml
+
+    @classmethod
+    def from_yaml(cls, yaml_str):
+        """
+        Construct table from YAML string
+        """
+        obj = yaml.load(yaml_str)
+        acqs = cls.from_struct(obj.pop('acqs'))
+        acqs.meta['cand_acqs'] = cls.from_struct(obj.pop('cand_acqs'))
+        acqs.log_info.update(obj.pop('log_info'))
+
+        for par in obj:
+            acqs.meta[par] = copy(obj[par])
+        return acqs
+
+    def to_struct(self):
+        """Turn table into a dict structure with keys:
+
+        - names: column names in order
+        - dtype: column dtypes as strings
+        - rows: list of dict with row values
+
+        This takes pains to remove any numpy objects so the YAML serialization
+        is tidy (pure-Python only).
+        """
+        rows = []
+        colnames = self.colnames
+        dtypes = [col.dtype.str for col in self.itercols()]
+        out = {'names': colnames, 'dtype': dtypes}
+
+        for row in self:
+            outrow = {}
+            for name in colnames:
+                val = row[name]
+                if isinstance(val, np.ndarray) and val.dtype.names:
+                    val = Table(val)
+
+                if isinstance(val, Table):
+                    val = AcqTable.to_struct(val)
+
+                elif isinstance(val, dict):
+                    new_val = {}
+                    for key, item in val.items():
+                        if isinstance(key, tuple):
+                            key = tuple(to_python(k) for k in key)
+                        else:
+                            key = to_python(key)
+                        item = to_python(item)
+                        new_val[key] = item
+                    val = new_val
+
+                else:
+                    val = to_python(val)
+
+                outrow[name] = val
+            rows.append(outrow)
+
+        # Only include rows=[..] kwarg if there are rows.  Table initializer is unhappy
+        # with a zero-length list for rows, but is OK with just names=[..] dtype=[..].
+        if rows:
+            out['rows'] = rows
+
+        return out
+
+    @classmethod
+    def from_struct(cls, struct):
+        out = cls(**struct)
+        for name in out.colnames:
+            col = out[name]
+            if col.dtype.kind == 'O':
+                for idx, val in enumerate(col):
+                    if isinstance(val, dict) and 'dtype' in val.keys():
+                        col[idx] = Table(**val)
+        return out
+
+
+# AGASC columns not needed (at this moment) for acq star selection.
+# Change as needed.
+AGASC_COLS_DROP = [
+    'RA',
+    'DEC',
+    'POS_CATID',
+    'EPOCH',
+    'PM_CATID',
+    'PLX',
+    'PLX_ERR',
+    'PLX_CATID',
+    'MAG',
+    'MAG_ERR',
+    'MAG_BAND',
+    'MAG_CATID',
+    'C1_CATID',
+    'COLOR2',
+    'COLOR2_ERR',
+    'C2_CATID',
+    'RSV1',
+    'RSV2',
+    'RSV3',
+    'VAR_CATID',
+    'ACQQ1',
+    'ACQQ2',
+    'ACQQ3',
+    'ACQQ4',
+    'ACQQ5',
+    'ACQQ6',
+    'XREF_ID1',
+    'XREF_ID2',
+    'XREF_ID3',
+    'XREF_ID4',
+    'XREF_ID5',
+    'RSV4',
+    'RSV5',
+    'RSV6',
+]
+
+# Define a function that returns the observed standard deviation in ACA mag
+# as a function of catalog mag.  This is about the std-dev for samples
+# within an observation, NOT the error on the catalog mag (which is about
+# the error on mean of the sample, not the std-dev of the sample).
+#
+# See skanb/star_selection/star-mag-std-dev.ipynb for the source of numbers.
+#
+# Note that get_mag_std is a function that is called with get_mag_std(mag_aca).
+get_mag_std = interp1d(x=[-10, 6.7, 7.3, 7.8, 8.3, 8.8, 9.2, 9.7, 10.1, 11, 20],  # mag
+                       y=[0.015, 0.015, 0.022, 0.029, 0.038, 0.055, 0.077,
+                          0.109, 0.141, 0.23, 1.0],  # std-dev
+                       kind='linear')
+
+
+def get_stars(att, date=None, radius=1.2, logger=None):
+    """
+    Get AGASC stars in the ACA FOV.  This uses the mini-AGASC, so only stars
+    within 3-sigma of 11.5 mag.  TO DO: maybe use the full AGASC, for faint
+    candidate acq stars with large uncertainty.
+    """
+    if logger is None:
+        def logger(*args, **kwargs):
+            return None
+
+    q_att = Quat(att)
+    logger('Getting stars at ra={:.5f} dec={:.4f}'.format(q_att.ra, q_att.dec))
+    stars = get_agasc_cone(q_att.ra, q_att.dec, radius=radius, date=date)
+    logger('Got {} stars'.format(len(stars)), level=1)
+    yag, zag = radec2yagzag(stars['RA_PMCORR'], stars['DEC_PMCORR'], q_att)
+    yag *= 3600
+    zag *= 3600
+    row, col = yagzag_to_pixels(yag, zag, allow_bad=True, pix_zero_loc='edge')
+
+    stars.remove_columns(AGASC_COLS_DROP)
+
+    stars.rename_column('AGASC_ID', 'id')
+    stars.add_column(Column(stars['RA_PMCORR'], name='ra'), index=1)
+    stars.add_column(Column(stars['DEC_PMCORR'], name='dec'), index=2)
+    stars.add_column(Column(yag, name='yang'), index=3)
+    stars.add_column(Column(zag, name='zang'), index=4)
+    stars.add_column(Column(row, name='row'), index=5)
+    stars.add_column(Column(col, name='col'), index=6)
+
+    stars.add_column(Column(stars['MAG_ACA'], name='mag'), index=7)  # For convenience
+
+    # Mag_err column is the RSS of the catalog mag err (i.e. systematic error in
+    # the true star mag) and the sample uncertainty in the ACA readout mag
+    # for a star with mag=MAG_ACA.  The latter typically dominates above 9th mag.
+    mag_aca_err = stars['MAG_ACA_ERR'] * 0.01
+    mag_std_dev = get_mag_std(stars['MAG_ACA'])
+    mag_err = np.sqrt(mag_aca_err ** 2 + mag_std_dev ** 2)
+    stars.add_column(Column(mag_err, name='mag_err'), index=8)
+
+    # Filter stars in or near ACA FOV
+    rcmax = 512.0 + 200 / 5  # 200 arcsec padding around CCD edge
+    ok = (row > -rcmax) & (row < rcmax) & (col > -rcmax) & (col < rcmax)
+    stars = stars[ok]
+
+    logger('Finished star processing', level=1)
+
+    return stars

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -4,7 +4,7 @@
 from __future__ import division, print_function, absolute_import  # For Py2 compatibility
 
 import os
-from copy import copy
+from copy import copy, deepcopy
 import re
 
 import matplotlib
@@ -115,7 +115,7 @@ def select_events(events, funcs, **select):
 
 def make_events(acqs):
     # Set up global events
-    events = copy(acqs.log_info['events'])
+    events = deepcopy(acqs.log_info['events'])
     for event in events:
         event['func_disp'] = event['func']
     last = events[0]
@@ -181,6 +181,9 @@ def make_cand_acqs_report(acqs, cand_acqs, events, context, obsdir):
                                   bad_stars=acqs.meta['bad_stars'])
         fig.savefig(filename)
         plt.close(fig)
+
+        # Restore original type designation
+        acqs.meta['cand_acqs']['type'] = 'ACQ'
 
 
 def make_initial_cat_report(events, context):
@@ -314,7 +317,7 @@ def make_report(obsid, rootdir='.'):
     context = copy(acqs.meta)
 
     # Get information that is not stored in the info.yaml for space reasons
-    acqs.meta['stars'] = get_stars(acqs, acqs.meta['att'])
+    acqs.meta['stars'] = get_stars(acqs.meta['att'], date=acqs.meta['date'])
     _, acqs.meta['bad_stars'] = get_acq_candidates(acqs, acqs.meta['stars'])
 
     events = make_events(acqs)

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -18,7 +18,7 @@ from astropy.table import Table, Column
 from chandra_aca.aca_image import ACAImage
 
 from . import characteristics as CHAR
-from .acq import AcqTable, get_stars, get_acq_candidates
+from .acq import AcqTable, get_stars
 from chandra_aca import plot as plot_aca
 from mica.archive.aca_dark.dark_cal import get_dark_cal_image
 
@@ -318,7 +318,7 @@ def make_report(obsid, rootdir='.'):
 
     # Get information that is not stored in the info.yaml for space reasons
     acqs.meta['stars'] = get_stars(acqs.meta['att'], date=acqs.meta['date'])
-    _, acqs.meta['bad_stars'] = get_acq_candidates(acqs, acqs.meta['stars'])
+    _, acqs.meta['bad_stars'] = acqs.get_acq_candidates(acqs.meta['stars'])
 
     events = make_events(acqs)
     context['events'] = events

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -13,7 +13,6 @@ from ..acq import (get_p_man_err, bin2x2, CHAR,
                    get_imposter_stars, get_stars, get_acq_candidates,
                    get_image_props, calc_p_brightest,
                    calc_p_on_ccd,
-                   get_acq_catalog,
                    AcqTable,
                    )
 
@@ -262,12 +261,12 @@ def test_get_acq_catalog_19387():
     actually changes out one of the initial catalog candidates.
 
     From ipython:
-    >>> from proseco import acq
-    >>> acqs = acq.get_acq_catalog(19387)
+    >>> from proseco.acq import AcqTable
+    >>> acqs = AcqTable.get_acq_catalog(19387)
     >>> TEST_COLS = ('idx', 'slot', 'id', 'yang', 'zang', 'halfw', 'mag', 'p_acq')
     >>> repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines()
     """
-    acqs = get_acq_catalog(19387)
+    acqs = AcqTable.get_acq_catalog(19387)
     # Expected
     exp = ['<AcqTable length=11>',
            ' idx  slot    id      yang     zang   halfw   mag    p_acq ',
@@ -291,12 +290,12 @@ def test_get_acq_catalog_19387():
 def test_get_acq_catalog_21007():
     """Put it all together.  Regression test for selected stars.
     From ipython:
-    >>> from proseco import acq
-    >>> acqs = acq.get_acq_catalog(21007)
+    >>> from proseco.acq import AcqTable
+    >>> acqs = AcqTable.get_acq_catalog(21007)
     >>> TEST_COLS = ('idx', 'slot', 'id', 'yang', 'zang', 'halfw', 'mag', 'p_acq')
     >>> repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines()
     """
-    acqs = get_acq_catalog(21007)
+    acqs = AcqTable.get_acq_catalog(21007)
     exp = ['<AcqTable length=14>',
            ' idx  slot     id      yang     zang   halfw   mag    p_acq ',
            'int64 str3   int32   float64  float64  int64 float32 float64',
@@ -323,7 +322,7 @@ def test_box_strategy_20603():
     """Test for PR #32 that doesn't allow p_acq to be reduced below 0.1.
     The idx=8 (mag=10.50) star was previously selected with 160 arsec box.
     """
-    acqs = get_acq_catalog(20603)
+    acqs = AcqTable.get_acq_catalog(20603)
     exp = ['<AcqTable length=13>',
            ' idx  slot     id      yang     zang   halfw   mag    p_acq ',
            'int64 str3   int32   float64  float64  int64 float32 float64',
@@ -350,7 +349,7 @@ def test_make_report(tmpdir):
     tmpdir = Path(tmpdir)
     obsdir = tmpdir / f'obs{obsid:05}'
 
-    acqs = get_acq_catalog(obsid)
+    acqs = AcqTable.get_acq_catalog(obsid)
     acqs.to_yaml(rootdir=tmpdir)
 
     acqs2 = make_report(obsid, rootdir=tmpdir)

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -155,8 +155,7 @@ def test_get_imposters_5000():
 
 def get_test_stars():
     if 'stars' not in CACHE:
-        acqs = AcqTable()
-        CACHE['stars'] = get_stars(acqs, ATT)
+        CACHE['stars'] = get_stars(ATT, date='2018:230')
     return CACHE['stars']
 
 

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -10,7 +10,7 @@ from chandra_aca.transform import mag_to_count_rate, yagzag_to_pixels
 
 from ..report import make_report
 from ..acq import (get_p_man_err, bin2x2, CHAR,
-                   get_imposter_stars, get_stars, get_acq_candidates,
+                   get_imposter_stars, get_stars,
                    get_image_props, calc_p_brightest,
                    calc_p_on_ccd,
                    AcqTable,
@@ -164,7 +164,7 @@ def get_test_cand_acqs():
     if 'cand_acqs' not in CACHE:
         acqs = AcqTable()
         stars = get_test_stars()
-        CACHE['cand_acqs'], bads = get_acq_candidates(acqs, stars)
+        CACHE['cand_acqs'], bads = acqs.get_acq_candidates(stars)
         # Don't care about bads for testing
     return CACHE['cand_acqs'].copy()
 


### PR DESCRIPTION
This does a few key things:

- Make a `core.py` module where common functions and classes can live
- Make a base `ACACatalogTable` class that is the base class for `AcqTable` and should be the base class for a similar `GuideTable` and `FidTable`.  (Not clear if we *need* a `FidTable` but it will probably be useful).
- Note, the current `ACACatalogTable` has stuff that is still specific to Acq, will fix.
- Change a number acq selection functions to be `AcqTable` methods.  This was applied to functions that already had `acqs` as the first arg, i.e. they were basically instance methods already.
- API change, getting an acq catalog is now a class method call: `AcqTable.get_acq_catalog(..)`.

The overall diffs are basically not reviewable, but this passes tests.

The bigger plan is a new module and function that stitches acq, guide, fid functionality together and provides the interface to Matlab.  Details TBD.