### PR TITLE
More refactor and support for pickle serialization

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -20,20 +20,116 @@ from .core import (get_mag_std, get_stars, ACACatalogTable, bin2x2,
                    get_image_props, pea_reject_image)
 
 
-def get_p_man_err(man_err, man_angle):
+def get_acq_catalog(obsid=0, att=None,
+                    man_angle=None, t_ccd=None, date=None, dither=None,
+                    optimize=True, verbose=False, print_log=False):
     """
-    Probability for given ``man_err`` given maneuver angle ``man_angle``.
+    Get a catalog of acquisition stars using the algorithm described in
+    https://docs.google.com/presentation/d/1VtFKAW9he2vWIQAnb6unpK4u1bVAVziIdX9TnqRS3a8
+
+    If ``obsid`` corresponds to an already-scheduled obsid then the parameters
+    ``att``, ``man_angle``, ``t_ccd``, ``date``, and ``dither`` will
+    be fetched via ``mica.starcheck`` if not explicitly provided here.
+
+    :param obsid: obsid (default=0)
+    :param att: attitude (any object that can initialize Quat)
+    :param man_angle: maneuver angle (deg)
+    :param t_ccd: ACA CCD temperature (degC)
+    :param date: date of acquisition (any DateTime-compatible format)
+    :param dither: dither size (float, arcsec)
+    :param optimize: optimize star catalog after initial selection (default=True)
+    :param verbose: provide extra logging info (mostly calc_p_safe) (default=False)
+    :param print_log: print the run log to stdout (default=False)
+
+    :returns: AcqTable of acquisition stars
     """
-    pmea = CHAR.p_man_errs_angles  # [0, 5, 20, 40, 60, 80, 100, 120, 180]
-    pme = CHAR.p_man_errs
-    man_angle_idx = np.searchsorted(pmea, man_angle) if (man_angle > 0) else 1
-    name = '{}-{}'.format(pmea[man_angle_idx - 1], pmea[man_angle_idx])
 
-    man_err_idx = np.searchsorted(pme['man_err_hi'], man_err)
-    if man_err_idx == len(pme):
-        raise ValueError(f'man_err must be <= {pme["man_err_hi"]}')
+    # Make an empty AcqTable object, mostly for logging.  It gets populated
+    # after selecting initial an inital catalog of potential acq stars.
+    acqs = AcqTable(print_log=print_log)
 
-    return pme[name][man_err_idx]
+    # If an explicit obsid is not provided to all getting parameters via mica
+    # then all other params must be supplied.
+    all_pars = all(x is not None for x in (att, man_angle, t_ccd, date, dither))
+    if obsid == 0 and not all_pars:
+        raise ValueError('if `obsid` not supplied then all other params are required')
+
+    # If not all params supplied then get via mica for the obsid.
+    if not all_pars:
+        from mica.starcheck import get_starcheck_catalog
+        acqs.log(f'getting starcheck catalog for obsid {obsid}')
+
+        obs = get_starcheck_catalog(obsid)
+        obso = obs['obs']
+
+        if att is None:
+            att = [obso['point_ra'], obso['point_dec'], obso['point_roll']]
+        if date is None:
+            date = obso['mp_starcat_time']
+        if t_ccd is None:
+            t_ccd = obs['pred_temp']
+        if man_angle is None:
+            man_angle = obs['manvr']['angle_deg'][0]
+
+        # TO DO: deal with non-square dither pattern, esp. 8 x 64.
+        dither_y_amp = obso.get('dither_y_amp')
+        dither_z_amp = obso.get('dither_z_amp')
+        if dither_y_amp is not None and dither_z_amp is not None:
+            dither = max(dither_y_amp, dither_z_amp)
+
+        if dither is None:
+            dither = 20
+
+    acqs.log(f'getting dark cal image at date={date} t_ccd={t_ccd:.1f}')
+    dark = get_dark_cal_image(date=date, select='before', t_ccd_ref=t_ccd)
+
+    acqs.meta = {'obsid': obsid,
+                 'att': att,
+                 'date': date,
+                 't_ccd': t_ccd,
+                 'man_angle': man_angle,
+                 'dither': dither}
+
+    # Probability of man_err for this observation with a given man_angle.  Used
+    # for marginalizing probabilities over different man_errs.
+    acqs.meta['p_man_errs'] = np.array([get_p_man_err(man_err, acqs.meta['man_angle'])
+                                        for man_err in CHAR.man_errs])
+
+    stars = get_stars(att, date=date, logger=acqs.log)
+    cand_acqs, bad_stars = acqs.get_acq_candidates(stars)
+
+    # Fill in the entire acq['probs'].p_acqs table (which is actual a dict of keyed by
+    # (box_size, man_err) tuples).
+    for acq in cand_acqs:
+        acq['probs'] = AcqProbs(acqs, acq, dither, stars, dark, t_ccd, date,
+                                acqs.meta['man_angle'])
+
+    acqs.get_initial_catalog(cand_acqs, stars=stars, dark=dark, dither=dither,
+                             t_ccd=t_ccd, date=date)
+
+    acqs.meta.update({'cand_acqs': cand_acqs,
+                      'stars': stars,
+                      'dark': dark,
+                      'bad_stars': bad_stars})
+
+    if optimize:
+        acqs.optimize_catalog(verbose)
+
+    # Set p_acq column to be the marginalized probabilities
+    acqs['p_acq'] = [acq['probs'].p_acq_marg[acq['halfw']] for acq in acqs]
+
+    # Sort to make order match the original candidate list order (by
+    # increasing mag), and assign a slot.
+    acqs.sort('idx')
+    acqs['slot'] = np.arange(len(acqs))
+
+    # Add slot to cand_acqs table, putting in '...' if not selected as acq.
+    # This is for convenience in downstream reporting or introspection.
+    slots = [str(acqs.get_id(acq['id'])['slot']) if acq['id'] in acqs['id'] else '...'
+             for acq in cand_acqs]
+    cand_acqs['slot'] = slots
+
+    return acqs
 
 
 class AcqTable(ACACatalogTable):
@@ -44,118 +140,6 @@ class AcqTable(ACACatalogTable):
     # Name of table.  Use to define default file names where applicable.
     # (e.g. `obs19387/acqs.yaml`).
     name = 'acqs'
-
-    @classmethod
-    def get_acq_catalog(cls, obsid=0, att=None,
-                        man_angle=None, t_ccd=None, date=None, dither=None,
-                        optimize=True, verbose=False, print_log=False):
-        """
-        Get a catalog of acquisition stars using the algorithm described in
-        https://docs.google.com/presentation/d/1VtFKAW9he2vWIQAnb6unpK4u1bVAVziIdX9TnqRS3a8
-
-        If ``obsid`` corresponds to an already-scheduled obsid then the parameters
-        ``att``, ``man_angle``, ``t_ccd``, ``date``, and ``dither`` will
-        be fetched via ``mica.starcheck`` if not explicitly provided here.
-
-        :param obsid: obsid (default=0)
-        :param att: attitude (any object that can initialize Quat)
-        :param man_angle: maneuver angle (deg)
-        :param t_ccd: ACA CCD temperature (degC)
-        :param date: date of acquisition (any DateTime-compatible format)
-        :param dither: dither size (float, arcsec)
-        :param optimize: optimize star catalog after initial selection (default=True)
-        :param verbose: provide extra logging info (mostly calc_p_safe) (default=False)
-        :param print_log: print the run log to stdout (default=False)
-
-        :returns: AcqTable of acquisition stars
-        """
-
-        # Make an empty AcqTable object, mostly for logging.  It gets populated
-        # after selecting initial an inital catalog of potential acq stars.
-        acqs = cls(print_log=print_log)
-
-        # If an explicit obsid is not provided to all getting parameters via mica
-        # then all other params must be supplied.
-        all_pars = all(x is not None for x in (att, man_angle, t_ccd, date, dither))
-        if obsid == 0 and not all_pars:
-            raise ValueError('if `obsid` not supplied then all other params are required')
-
-        # If not all params supplied then get via mica for the obsid.
-        if not all_pars:
-            from mica.starcheck import get_starcheck_catalog
-            acqs.log(f'getting starcheck catalog for obsid {obsid}')
-
-            obs = get_starcheck_catalog(obsid)
-            obso = obs['obs']
-
-            if att is None:
-                att = [obso['point_ra'], obso['point_dec'], obso['point_roll']]
-            if date is None:
-                date = obso['mp_starcat_time']
-            if t_ccd is None:
-                t_ccd = obs['pred_temp']
-            if man_angle is None:
-                man_angle = obs['manvr']['angle_deg'][0]
-
-            # TO DO: deal with non-square dither pattern, esp. 8 x 64.
-            dither_y_amp = obso.get('dither_y_amp')
-            dither_z_amp = obso.get('dither_z_amp')
-            if dither_y_amp is not None and dither_z_amp is not None:
-                dither = max(dither_y_amp, dither_z_amp)
-
-            if dither is None:
-                dither = 20
-
-        acqs.log(f'getting dark cal image at date={date} t_ccd={t_ccd:.1f}')
-        dark = get_dark_cal_image(date=date, select='before', t_ccd_ref=t_ccd)
-
-        acqs.meta = {'obsid': obsid,
-                     'att': att,
-                     'date': date,
-                     't_ccd': t_ccd,
-                     'man_angle': man_angle,
-                     'dither': dither}
-
-        # Probability of man_err for this observation with a given man_angle.  Used
-        # for marginalizing probabilities over different man_errs.
-        acqs.meta['p_man_errs'] = np.array([get_p_man_err(man_err, acqs.meta['man_angle'])
-                                            for man_err in CHAR.man_errs])
-
-        stars = get_stars(att, date=date, logger=acqs.log)
-        cand_acqs, bad_stars = acqs.get_acq_candidates(stars)
-
-        # Fill in the entire acq['probs'].p_acqs table (which is actual a dict of keyed by
-        # (box_size, man_err) tuples).
-        for acq in cand_acqs:
-            acq['probs'] = AcqProbs(acqs, acq, dither, stars, dark, t_ccd, date,
-                                    acqs.meta['man_angle'])
-
-        acqs.get_initial_catalog(cand_acqs, stars=stars, dark=dark, dither=dither,
-                                 t_ccd=t_ccd, date=date)
-
-        acqs.meta.update({'cand_acqs': cand_acqs,
-                          'stars': stars,
-                          'dark': dark,
-                          'bad_stars': bad_stars})
-
-        if optimize:
-            acqs.optimize_catalog(verbose)
-
-        # Set p_acq column to be the marginalized probabilities
-        acqs['p_acq'] = [acq['probs'].p_acq_marg[acq['halfw']] for acq in acqs]
-
-        # Sort to make order match the original candidate list order (by
-        # increasing mag), and assign a slot.
-        acqs.sort('idx')
-        acqs['slot'] = np.arange(len(acqs))
-
-        # Add slot to cand_acqs table, putting in '...' if not selected as acq.
-        # This is for convenience in downstream reporting or introspection.
-        slots = [str(acqs.get_id(acq['id'])['slot']) if acq['id'] in acqs['id'] else '...'
-                 for acq in cand_acqs]
-        cand_acqs['slot'] = slots
-
-        return acqs
 
     def get_acq_candidates(self, stars, max_candidates=20):
         """
@@ -858,3 +842,19 @@ class AcqProbs:
                                                   self.p_on_ccd[man_err])
                 p_acq_marg += self.p_acqs[box_size, man_err] * p_man_err
             self.p_acq_marg[box_size] = p_acq_marg
+
+
+def get_p_man_err(man_err, man_angle):
+    """
+    Probability for given ``man_err`` given maneuver angle ``man_angle``.
+    """
+    pmea = CHAR.p_man_errs_angles  # [0, 5, 20, 40, 60, 80, 100, 120, 180]
+    pme = CHAR.p_man_errs
+    man_angle_idx = np.searchsorted(pmea, man_angle) if (man_angle > 0) else 1
+    name = '{}-{}'.format(pmea[man_angle_idx - 1], pmea[man_angle_idx])
+
+    man_err_idx = np.searchsorted(pme['man_err_hi'], man_err)
+    if man_err_idx == len(pme):
+        raise ValueError(f'man_err must be <= {pme["man_err_hi"]}')
+
+    return pme[name][man_err_idx]

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -136,6 +136,7 @@ class AcqTable(ACACatalogTable):
     # Elements of meta that should not be directly serialized to YAML
     # (either too big or requires special handling).
     yaml_exclude = ('stars', 'cand_acqs', 'dark', 'bad_stars')
+    pickle_exclude = ('stars', 'dark', 'bad_stars')
 
     # Name of table.  Use to define default file names where applicable.
     # (e.g. `obs19387/acqs.yaml`).

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -5,6 +5,7 @@
 Get a catalog of acquisition stars using the algorithm described in
 https://docs.google.com/presentation/d/1VtFKAW9he2vWIQAnb6unpK4u1bVAVziIdX9TnqRS3a8
 """
+import weakref
 
 import numpy as np
 from scipy import ndimage, stats
@@ -123,10 +124,11 @@ class AcqTable(ACACatalogTable):
         stars = get_stars(att, date=date, logger=acqs.log)
         cand_acqs, bad_stars = acqs.get_acq_candidates(stars)
 
-        # Fill in the entire acq['p_acqs'] table (which is actual a dict of keyed by
+        # Fill in the entire acq['probs'].p_acqs table (which is actual a dict of keyed by
         # (box_size, man_err) tuples).
         for acq in cand_acqs:
-            acqs.calc_acq_p_vals(acq, dither, stars, dark, t_ccd, date, acqs.meta['man_angle'])
+            acq['probs'] = AcqProbs(acqs, acq, dither, stars, dark, t_ccd, date,
+                                    acqs.meta['man_angle'])
 
         acqs.get_initial_catalog(cand_acqs, stars=stars, dark=dark, dither=dither,
                                  t_ccd=t_ccd, date=date)
@@ -140,7 +142,7 @@ class AcqTable(ACACatalogTable):
             acqs.optimize_catalog(verbose)
 
         # Set p_acq column to be the marginalized probabilities
-        acqs['p_acq'] = [acq['p_acq_marg'][acq['halfw']] for acq in acqs]
+        acqs['p_acq'] = [acq['probs'].p_acq_marg[acq['halfw']] for acq in acqs]
 
         # Sort to make order match the original candidate list order (by
         # increasing mag), and assign a slot.
@@ -223,11 +225,7 @@ class AcqTable(ACACatalogTable):
             return [{} for _ in range(len(cand_acqs))]
 
         cand_acqs['p_acq'] = -999.0  # Acq prob for box_size=halfw, marginalized over man_err
-        cand_acqs['p_acqs'] = empty_dicts()  # Dict keyed on (box_size, man_err) (mult next 3)
-        cand_acqs['p_brightest'] = empty_dicts()  # Dict keyed on (box_size, man_err)
-        cand_acqs['p_acq_model'] = empty_dicts()  # Dict keyed on box_size
-        cand_acqs['p_on_ccd'] = empty_dicts()  # Dict keyed on box_size
-        cand_acqs['p_acq_marg'] = empty_dicts()  # Dict keyed on box_size
+        cand_acqs['probs'] = empty_dicts()  # Dict keyed on (box_size, man_err) (mult next 3)
 
         cand_acqs['spoilers'] = None  # Filled in with Table of spoilers
         cand_acqs['imposters'] = None  # Filled in with Table of imposters
@@ -260,7 +258,7 @@ class AcqTable(ACACatalogTable):
         for box_size in CHAR.box_sizes:
             # Get array of marginalized (over man_err) p_acq values corresponding
             # to box_size for each of the candidate acq stars.
-            p_acqs_for_box = np.array([acq['p_acq_marg'][box_size] for acq in cand_acqs])
+            p_acqs_for_box = np.array([acq['probs'].p_acq_marg[box_size] for acq in cand_acqs])
 
             self.log(f'Trying search box size {box_size} arcsec', level=1)
 
@@ -287,67 +285,6 @@ class AcqTable(ACACatalogTable):
                     self.log('Found 8 acq stars, done')
                     return
 
-    def calc_acq_p_vals(self, acq, dither, stars, dark, t_ccd, date, man_angle):
-        """
-        Calculate probabilities related to acquisition, in particular an element
-        in the ``p_acqs`` matrix which specifies star acquisition probability
-        for given search box size and maneuver error.
-
-        This updates the ``acq`` row in place, including these columns:
-
-        - ``p_brightest``: probability this star is the brightest in box (function
-            of ``box_size`` and ``man_err``)
-        - ``p_acq_model``: probability of acquisition from the chandra_aca model
-            (function of ``box_size``)
-        - ``p_on_ccd``: probability star is on the usable part of the CCD (function
-            of ``man_err`` and ``dither``)
-        - ``p_acqs``: product of the above three
-
-        :param acq: row in the acqs table
-        :param dither: dither (arcsec)
-        :param stars: stars table
-        :param dark: dark current map
-        :param t_ccd: CCD temperature (degC)
-        :param date: observation date
-        """
-        for box_size in CHAR.box_sizes:
-            # Need to iterate over man_errs in reverse order because calc_p_brightest
-            # caches interlopers based on first call, so that needs to have the largest
-            # box sizes.
-            for man_err in CHAR.man_errs[::-1]:
-                if man_err > box_size:
-                    p_brightest = acq['p_brightest'][box_size, man_err] = 0.0
-                else:
-                    # Prob of being brightest in box (function of box_size and
-                    # man_err, independently because imposter prob is just a
-                    # function of box_size not man_err).  Technically also a
-                    # function of dither, but that does not vary here.
-                    p_brightest = calc_p_brightest(acq, box_size=box_size, stars=stars, dark=dark,
-                                                   man_err=man_err, dither=dither)
-                    acq['p_brightest'][box_size, man_err] = p_brightest
-
-        # Acquisition probability model value (function of box_size only)
-        for box_size in CHAR.box_sizes:
-            p_acq_model = acq_success_prob(date=date, t_ccd=t_ccd,
-                                           mag=acq['mag'], color=acq['color'],
-                                           spoiler=False, halfwidth=box_size)
-            acq['p_acq_model'][box_size] = p_acq_model
-
-        # Probability star is in acq box (function of man_err and dither only)
-        for man_err in CHAR.man_errs:
-            p_on_ccd = calc_p_on_ccd(acq['row'], acq['col'], box_size=man_err + dither)
-            acq['p_on_ccd'][man_err] = p_on_ccd
-
-        # All together now!
-        for box_size in CHAR.box_sizes:
-            p_acq_marg = 0.0
-            for man_err, p_man_err in zip(CHAR.man_errs, self.meta['p_man_errs']):
-                acq['p_acqs'][box_size, man_err] = (acq['p_brightest'][box_size, man_err] *
-                                                    acq['p_acq_model'][box_size] *
-                                                    acq['p_on_ccd'][man_err])
-                p_acq_marg += acq['p_acqs'][box_size, man_err] * p_man_err
-            acq['p_acq_marg'][box_size] = p_acq_marg
-
     def get_initial_catalog(self, cand_acqs, stars, dark, dither=20, t_ccd=-11.0, date=None):
         """
         Get the initial catalog of up to 8 candidate acquisition stars.
@@ -371,7 +308,7 @@ class AcqTable(ACACatalogTable):
         cand_acqs['halfw'] = 120
         cand_acqs['halfw'][acq_indices] = box_sizes
         for acq in cand_acqs:
-            acq['p_acq'] = acq['p_acq_marg'][acq['halfw']]
+            acq['p_acq'] = acq['probs'].p_acq_marg[acq['halfw']]
 
         # Finally select the initial catalog
         acqs_init = cand_acqs[acq_indices]
@@ -387,7 +324,7 @@ class AcqTable(ACACatalogTable):
             if p_man_err == 0.0:
                 continue
 
-            p_acqs = [acq['p_acqs'][acq['halfw'], man_err] for acq in self]
+            p_acqs = [acq['probs'].p_acqs[acq['halfw'], man_err] for acq in self]
 
             p_n_cum = prob_n_acq(p_acqs)[1]
             if verbose:
@@ -410,14 +347,14 @@ class AcqTable(ACACatalogTable):
         """
         acq = self[idx]
         orig_halfw = acq['halfw']
-        orig_p_acq = acq['p_acq_marg'][acq['halfw']]
+        orig_p_acq = acq['probs'].p_acq_marg[acq['halfw']]
 
         self.log(f'Optimizing halfw for idx={idx} id={acq["id"]}', id=acq['id'])
 
         # Compute p_safe for each possible halfw for the current star
         p_safes = []
         for box_size in CHAR.box_sizes:
-            new_p_acq = acq['p_acq_marg'][box_size]
+            new_p_acq = acq['probs'].p_acq_marg[box_size]
             # Do not reduce marginalized p_acq to below 0.1.  It can happen that p_safe
             # goes down very slightly with an increase in box size from the original,
             # and then the box size gets stuck there because of the deadband for later
@@ -496,7 +433,7 @@ class AcqTable(ACACatalogTable):
                 acq_ids.add(cand_id)
 
             # Get the index of the worst p_acq in the catalog
-            p_acqs = [acq['p_acq_marg'][acq['halfw']] for acq in self]
+            p_acqs = [acq['probs'].p_acq_marg[acq['halfw']] for acq in self]
             idx = np.argsort(p_acqs)[0]
 
             self.log('Trying to use {} mag={:.2f} to replace idx={} with p_acq={:.3f}'
@@ -853,3 +790,71 @@ def calc_p_on_ccd(row, col, box_size):
     return p_on_ccd
 
 
+class AcqProbs:
+    def __init__(self, acqs, acq, dither, stars, dark, t_ccd, date, man_angle):
+        """
+        Calculate probabilities related to acquisition, in particular an element
+        in the ``p_acqs`` matrix which specifies star acquisition probability
+        for given search box size and maneuver error.
+
+        This sets these attributes:
+
+        - ``p_brightest``: probability this star is the brightest in box (function
+            of ``box_size`` and ``man_err``)
+        - ``p_acq_model``: probability of acquisition from the chandra_aca model
+            (function of ``box_size``)
+        - ``p_on_ccd``: probability star is on the usable part of the CCD (function
+            of ``man_err`` and ``dither``)
+        - ``p_acqs``: product of the above three
+
+        :param acqs: acqs table
+        :param acq: row in the candidate acqs table
+        :param dither: dither (arcsec)
+        :param stars: stars table
+        :param dark: dark current map
+        :param t_ccd: CCD temperature (degC)
+        :param date: observation date
+        """
+        self.p_brightest = {}
+        self.p_acq_model = {}
+        self.p_on_ccd = {}
+        self.p_acqs = {}
+        self.p_acq_marg = {}
+
+        for box_size in CHAR.box_sizes:
+            # Need to iterate over man_errs in reverse order because calc_p_brightest
+            # caches interlopers based on first call, so that needs to have the largest
+            # box sizes.
+            for man_err in CHAR.man_errs[::-1]:
+                if man_err > box_size:
+                    p_brightest = self.p_brightest[box_size, man_err] = 0.0
+                else:
+                    # Prob of being brightest in box (function of box_size and
+                    # man_err, independently because imposter prob is just a
+                    # function of box_size not man_err).  Technically also a
+                    # function of dither, but that does not vary here.
+                    p_brightest = calc_p_brightest(acq, box_size=box_size, stars=stars,
+                                                   dark=dark, man_err=man_err, dither=dither)
+                    self.p_brightest[box_size, man_err] = p_brightest
+
+        # Acquisition probability model value (function of box_size only)
+        for box_size in CHAR.box_sizes:
+            p_acq_model = acq_success_prob(date=date, t_ccd=t_ccd,
+                                           mag=acq['mag'], color=acq['color'],
+                                           spoiler=False, halfwidth=box_size)
+            self.p_acq_model[box_size] = p_acq_model
+
+        # Probability star is in acq box (function of man_err and dither only)
+        for man_err in CHAR.man_errs:
+            p_on_ccd = calc_p_on_ccd(acq['row'], acq['col'], box_size=man_err + dither)
+            self.p_on_ccd[man_err] = p_on_ccd
+
+        # All together now!
+        for box_size in CHAR.box_sizes:
+            p_acq_marg = 0.0
+            for man_err, p_man_err in zip(CHAR.man_errs, acqs.meta['p_man_errs']):
+                self.p_acqs[box_size, man_err] = (self.p_brightest[box_size, man_err] *
+                                                  self.p_acq_model[box_size] *
+                                                  self.p_on_ccd[man_err])
+                p_acq_marg += self.p_acqs[box_size, man_err] * p_man_err
+            self.p_acq_marg[box_size] = p_acq_marg

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -155,6 +155,16 @@ class AcqTable(ACACatalogTable):
     # (e.g. `obs19387/acqs.yaml`).
     name = 'acqs'
 
+    def get_obs_info(self):
+        """
+        Convenience method to return the parts of meta that are needed
+        for test_common OBS_INFO.
+
+        """
+        keys = ('obsid', 'att', 'date', 't_ccd', 'man_angle', 'dither',
+                'detector', 'sim_offset', 'focus_offset')
+        return {key: self.meta[key] for key in keys}
+
     def get_acq_candidates(self, stars, max_candidates=20):
         """
         Get candidates for acquisition stars from ``stars`` table.

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -22,6 +22,7 @@ from .core import (get_mag_std, get_stars, ACACatalogTable, bin2x2,
 
 def get_acq_catalog(obsid=0, att=None,
                     man_angle=None, t_ccd=None, date=None, dither=None,
+                    detector=None, sim_offset=None, focus_offset=None,
                     optimize=True, verbose=False, print_log=False):
     """
     Get a catalog of acquisition stars using the algorithm described in
@@ -37,6 +38,9 @@ def get_acq_catalog(obsid=0, att=None,
     :param t_ccd: ACA CCD temperature (degC)
     :param date: date of acquisition (any DateTime-compatible format)
     :param dither: dither size (float, arcsec)
+    :param detector: 'ACIS-S' | 'ACIS-I' | 'HRC-S' | 'HRC-I'
+    :param focus_offset: SIM focus offset [steps] (default=0)
+    :param sim_offset: SIM translation offset from nominal [steps] (default=0)
     :param optimize: optimize star catalog after initial selection (default=True)
     :param verbose: provide extra logging info (mostly calc_p_safe) (default=False)
     :param print_log: print the run log to stdout (default=False)
@@ -70,6 +74,12 @@ def get_acq_catalog(obsid=0, att=None,
             t_ccd = obs['pred_temp']
         if man_angle is None:
             man_angle = obs['manvr']['angle_deg'][0]
+        if detector is None:
+            detector = obso['sci_instr']
+        if sim_offset is None:
+            sim_offset = obso['sim_z_offset_steps']
+        if focus_offset is None:
+            focus_offset = 0
 
         # TO DO: deal with non-square dither pattern, esp. 8 x 64.
         dither_y_amp = obso.get('dither_y_amp')
@@ -88,7 +98,10 @@ def get_acq_catalog(obsid=0, att=None,
                  'date': date,
                  't_ccd': t_ccd,
                  'man_angle': man_angle,
-                 'dither': dither}
+                 'dither': dither,
+                 'detector': detector,
+                 'sim_offset': sim_offset,
+                 'focus_offset': focus_offset}
 
     # Probability of man_err for this observation with a given man_angle.  Used
     # for marginalizing probabilities over different man_errs.

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -206,7 +206,6 @@ class FidTable(ACACatalogTable):
         dz = np.abs(fid['zang'] - acq['zang'])
         return (dy < spoiler_margin and dz < spoiler_margin)
 
-
     def get_fid_candidates(self):
         """
         Get all fids for this detector that are on the CCD (with margin) and are not
@@ -311,7 +310,7 @@ class FidTable(ACACatalogTable):
 
         if not np.any(spoil):
             # Make an empty table with same columns
-            fid['spoilers'] = stars[[]]
+            fid['spoilers'] = []
         else:
             stars = stars[spoil]
 
@@ -322,7 +321,7 @@ class FidTable(ACACatalogTable):
 
             spoilers = stars[red | yellow]
             spoilers.sort('mag')
-            spoilers['warn'] = np.where(red, 'red', 'yellow')
+            spoilers['warn'] = np.where(red[red | yellow], 'red', 'yellow')
             fid['spoilers'] = spoilers
 
             if np.any(red):

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -79,6 +79,12 @@ class FidTable(ACACatalogTable):
                 stars = acqs.meta['stars']
             if dither is None:
                 dither = acqs.meta['dither']
+            if detector is None:
+                detector = acqs.meta['detector']
+            if sim_offset is None:
+                sim_offset = acqs.meta['sim_offset']
+            if focus_offset is None:
+                focus_offset = acqs.meta['focus_offset']
             if print_log is None:
                 print_log = acqs.print_log
             self.acqs = acqs

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -59,7 +59,7 @@ def get_p_acqs_table(acq, p_name):
     cols['box \ man_err'] = [f'{box_size}"' for box_size in box_sizes]
     for man_err in man_errs:
         name = f'{man_err}"'
-        cols[name] = [round(acq[p_name].get((box_size, man_err), 0.0), 3)
+        cols[name] = [round(getattr(acq['probs'], p_name).get((box_size, man_err), 0.0), 3)
                       for box_size in box_sizes]
 
     return table_to_html(Table(cols, names=names))
@@ -69,13 +69,8 @@ def get_p_on_ccd_table(acq):
     """
     Make HTML tables for an acq star for the following:
 
-    - ``p_brightest``: probability this star is the brightest in box (function
-        of ``box_size`` and ``man_err``)
-    - ``p_acq_model``: probability of acquisition from the chandra_aca model
-        (function of ``box_size``)
     - ``p_on_ccd``: probability star is on the usable part of the CCD (function
         of ``man_err`` and ``dither``)
-    - ``p_acqs``: product of the above three
     """
     man_errs = CHAR.p_man_errs['man_err_hi']
     names = ['man_err'] + [f'{man_err}"' for man_err in man_errs]
@@ -83,7 +78,7 @@ def get_p_on_ccd_table(acq):
     cols['man_err'] = ['']
     for man_err in man_errs:
         name = f'{man_err}"'
-        cols[name] = [round(acq['p_on_ccd'][man_err], 3)]
+        cols[name] = [round(acq['probs'].p_on_ccd[man_err], 3)]
 
     return table_to_html(Table(cols, names=names))
 
@@ -101,7 +96,7 @@ def get_p_acq_model_table(acq):
     cols['box size'] = ['']
     for box_size in box_sizes:
         name = f'{box_size}"'
-        cols[name] = [round(acq['p_acq_model'][box_size], 3)]
+        cols[name] = [round(acq['probs'].p_acq_model[box_size], 3)]
 
     return table_to_html(Table(cols, names=names))
 

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -234,6 +234,9 @@ def make_acq_star_details_report(acqs, cand_acqs, events, context, obsdir):
             plot_imposters(acq, acqs.meta['dark'], acqs.meta['dither'], filename=filename)
 
         if len(acq['imposters']) > 0:
+            if not isinstance(acq['imposters'], Table):
+                acq['imposters'] = Table(acq['imposters'])
+
             names = ('row0', 'col0', 'd_row', 'd_col', 'img_sum', 'mag', 'mag_err')
             fmts = ('d', 'd', '.0f', '.0f', '.0f', '.2f', '.2f')
             imposters = acq['imposters'][names]
@@ -248,6 +251,9 @@ def make_acq_star_details_report(acqs, cand_acqs, events, context, obsdir):
             cca['imposters_table'] = ''
 
         if len(acq['spoilers']) > 0:
+            if not isinstance(acq['spoilers'], Table):
+                acq['spoilers'] = Table(acq['spoilers'])
+
             names = ('id', 'yang', 'zang', 'mag', 'mag_err')
             fmts = ('d', '.1f', '.1f', '.2f', '.2f')
             spoilers = acq['spoilers'][names]
@@ -305,12 +311,12 @@ def make_report(obsid, rootdir='.'):
     print(f'Processing obsid {obsid}')
 
     obsdir = rootdir / f'obs{obsid:05}'
-    acqs = AcqTable.from_yaml(obsid, rootdir)
+    acqs = AcqTable.from_pickle(obsid, rootdir)
     cand_acqs = acqs.meta['cand_acqs']
 
     context = copy(acqs.meta)
 
-    # Get information that is not stored in the info.yaml for space reasons
+    # Get information that is not stored in the acqs pickle for space reasons
     acqs.meta['stars'] = get_stars(acqs.meta['att'], date=acqs.meta['date'])
     _, acqs.meta['bad_stars'] = acqs.get_acq_candidates(acqs.meta['stars'])
 

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -12,8 +12,8 @@ from ..report import make_report
 from ..acq import (get_p_man_err, bin2x2, CHAR,
                    get_imposter_stars, get_stars,
                    get_image_props, calc_p_brightest,
-                   calc_p_on_ccd,
-                   AcqTable,
+                   AcqTable, calc_p_on_ccd,
+                   get_acq_catalog,
                    )
 
 TEST_DATE = '2018:144'  # Fixed date for doing tests
@@ -262,7 +262,7 @@ def test_get_acq_catalog_19387():
 
     From ipython:
     >>> from proseco.acq import AcqTable
-    >>> acqs = AcqTable.get_acq_catalog(19387)
+    >>> acqs = get_acq_catalog(19387)
     >>> TEST_COLS = ('idx', 'slot', 'id', 'yang', 'zang', 'halfw', 'mag', 'p_acq')
     >>> repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines()
     """
@@ -272,8 +272,8 @@ def test_get_acq_catalog_19387():
     t_ccd = -14.1
     man_angle = 1.74
     dither = 4.0
-    acqs = AcqTable.get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
-                                    man_angle=man_angle, dither=dither)
+    acqs = get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
+                           man_angle=man_angle, dither=dither)
     # Expected
     exp = ['<AcqTable length=11>',
            ' idx  slot    id      yang     zang   halfw   mag    p_acq ',
@@ -298,7 +298,7 @@ def test_get_acq_catalog_21007():
     """Put it all together.  Regression test for selected stars.
     From ipython:
     >>> from proseco.acq import AcqTable
-    >>> acqs = AcqTable.get_acq_catalog(21007)
+    >>> acqs = get_acq_catalog(21007)
     >>> TEST_COLS = ('idx', 'slot', 'id', 'yang', 'zang', 'halfw', 'mag', 'p_acq')
     >>> repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines()
     """
@@ -308,8 +308,8 @@ def test_get_acq_catalog_21007():
     t_ccd = -11.3
     man_angle = 60.39
     dither = 8.0
-    acqs = AcqTable.get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
-                                    man_angle=man_angle, dither=dither)
+    acqs = get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
+                           man_angle=man_angle, dither=dither)
 
     exp = ['<AcqTable length=14>',
            ' idx  slot     id      yang     zang   halfw   mag    p_acq ',
@@ -343,8 +343,8 @@ def test_box_strategy_20603():
     t_ccd = -11.2
     man_angle = 111.95
     dither = 8.0
-    acqs = AcqTable.get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
-                                    man_angle=man_angle, dither=dither)
+    acqs = get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
+                           man_angle=man_angle, dither=dither)
 
     exp = ['<AcqTable length=13>',
            ' idx  slot     id      yang     zang   halfw   mag    p_acq ',
@@ -374,8 +374,8 @@ def test_make_report(tmpdir):
     t_ccd = -14.1
     man_angle = 1.74
     dither = 4.0
-    acqs = AcqTable.get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
-                                    man_angle=man_angle, dither=dither)
+    acqs = get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
+                           man_angle=man_angle, dither=dither)
 
     tmpdir = Path(tmpdir)
     obsdir = tmpdir / f'obs{obsid:05}'

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -15,6 +15,7 @@ from ..acq import (get_p_man_err, bin2x2, CHAR,
                    AcqTable, calc_p_on_ccd,
                    get_acq_catalog,
                    )
+from .test_common import OBS_INFO
 
 TEST_DATE = '2018:144'  # Fixed date for doing tests
 ATT = [10, 20, 3]  # Arbitrary test attitude
@@ -266,14 +267,7 @@ def test_get_acq_catalog_19387():
     >>> TEST_COLS = ('idx', 'slot', 'id', 'yang', 'zang', 'halfw', 'mag', 'p_acq')
     >>> repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines()
     """
-    obsid = 19387
-    att = [188.617671, 2.211623, 231.249803]
-    date = '2017:182:22:06:22.744'
-    t_ccd = -14.1
-    man_angle = 1.74
-    dither = 4.0
-    acqs = get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
-                           man_angle=man_angle, dither=dither)
+    acqs = get_acq_catalog(**OBS_INFO[19387])
     # Expected
     exp = ['<AcqTable length=11>',
            ' idx  slot    id      yang     zang   halfw   mag    p_acq ',
@@ -302,14 +296,7 @@ def test_get_acq_catalog_21007():
     >>> TEST_COLS = ('idx', 'slot', 'id', 'yang', 'zang', 'halfw', 'mag', 'p_acq')
     >>> repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines()
     """
-    obsid = 21007
-    att = [184.371121, 17.670062, 223.997765]
-    date = '2018:159:11:20:52.162'
-    t_ccd = -11.3
-    man_angle = 60.39
-    dither = 8.0
-    acqs = get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
-                           man_angle=man_angle, dither=dither)
+    acqs = get_acq_catalog(**OBS_INFO[21007])
 
     exp = ['<AcqTable length=14>',
            ' idx  slot     id      yang     zang   halfw   mag    p_acq ',
@@ -337,14 +324,7 @@ def test_box_strategy_20603():
     """Test for PR #32 that doesn't allow p_acq to be reduced below 0.1.
     The idx=8 (mag=10.50) star was previously selected with 160 arsec box.
     """
-    obsid = 20603
-    att = [201.561783, 7.748784, 205.998301]
-    date = '2018:120:19:06:28.154'
-    t_ccd = -11.2
-    man_angle = 111.95
-    dither = 8.0
-    acqs = get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
-                           man_angle=man_angle, dither=dither)
+    acqs = get_acq_catalog(**OBS_INFO[20603])
 
     exp = ['<AcqTable length=13>',
            ' idx  slot     id      yang     zang   halfw   mag    p_acq ',
@@ -369,13 +349,7 @@ def test_box_strategy_20603():
 
 def test_make_report(tmpdir):
     obsid = 19387
-    att = [188.617671, 2.211623, 231.249803]
-    date = '2017:182:22:06:22.744'
-    t_ccd = -14.1
-    man_angle = 1.74
-    dither = 4.0
-    acqs = get_acq_catalog(obsid=obsid, att=att, date=date, t_ccd=t_ccd,
-                           man_angle=man_angle, dither=dither)
+    acqs = get_acq_catalog(**OBS_INFO[obsid])
 
     tmpdir = Path(tmpdir)
     obsdir = tmpdir / f'obs{obsid:05}'

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -380,7 +380,7 @@ def test_make_report(tmpdir):
     tmpdir = Path(tmpdir)
     obsdir = tmpdir / f'obs{obsid:05}'
 
-    acqs.to_yaml(rootdir=tmpdir)
+    acqs.to_pickle(rootdir=tmpdir)
 
     acqs2 = make_report(obsid, rootdir=tmpdir)
 

--- a/proseco/tests/test_common.py
+++ b/proseco/tests/test_common.py
@@ -30,3 +30,13 @@ OBS_INFO[20603] = dict(obsid=20603,
                        t_ccd=-11.2,
                        man_angle=111.95,
                        dither=8.0)
+
+OBS_INFO[19605] = {'att': [350.897404, 58.836913, 75.068745],
+                   'date': '2018:135:15:52:08.898',
+                   'detector': 'ACIS-S',
+                   'dither': 8.0,
+                   'focus_offset': 0,
+                   'man_angle': 79.15,
+                   'obsid': 19605,
+                   'sim_offset': 0,
+                   't_ccd': -10.8}

--- a/proseco/tests/test_common.py
+++ b/proseco/tests/test_common.py
@@ -1,0 +1,32 @@
+# Parameters for test cases (to avoid starcheck.db3 dependence)
+OBS_INFO = {}
+
+OBS_INFO[19387] = dict(obsid=19387,
+                       detector='ACIS-S',
+                       sim_offset=0,
+                       focus_offset=0,
+                       att=[188.617671, 2.211623, 231.249803],
+                       date='2017:182:22:06:22.744',
+                       t_ccd=-14.1,
+                       man_angle=1.74,
+                       dither=4.0)
+
+OBS_INFO[21007] = dict(obsid=21007,
+                       detector='ACIS-S',
+                       sim_offset=0,
+                       focus_offset=0,
+                       att=[184.371121, 17.670062, 223.997765],
+                       date='2018:159:11:20:52.162',
+                       t_ccd=-11.3,
+                       man_angle=60.39,
+                       dither=8.0)
+
+OBS_INFO[20603] = dict(obsid=20603,
+                       detector='ACIS-S',
+                       sim_offset=0,
+                       focus_offset=0,
+                       att=[201.561783, 7.748784, 205.998301],
+                       date='2018:120:19:06:28.154',
+                       t_ccd=-11.2,
+                       man_angle=111.95,
+                       dither=8.0)

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -115,3 +115,15 @@ def test_get_initial_catalog():
            '    5 -1826.28   160.17  372.97   36.47    7.00             0    1',
            '    6   388.59   803.75  -71.49  166.10    7.00             0    2']
     assert repr(fids5.meta['cand_fids']).splitlines() == exp
+
+
+def test_fid_mult_spoilers():
+    """
+    Test of fix for bug #54.  19605 and 20144 were previous crashing.
+    """
+    acqs = get_acq_catalog(**OBS_INFO[19605])
+    fids = get_fid_catalog(acqs=acqs)
+    cand_fids = fids.meta['cand_fids']
+    assert np.all(cand_fids['spoiler_score'] == [0, 0, 1, 4, 0, 0])
+    assert len(cand_fids['spoilers'][2]) == 1
+    assert cand_fids['spoilers'][2]['warn'][0] == 'yellow'

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..fid import get_fid_positions, get_fid_catalog
-from ..acq import AcqTable
+from ..acq import get_acq_catalog
 from chandra_aca.transform import yagzag_to_pixels
 
 
@@ -93,7 +93,7 @@ def test_get_initial_catalog():
     # 20" + 20" + 10" + 100" + 4" = 154".  In this test 2, 4 should be
     # excluded but 5 should be OK.
 
-    acqs = AcqTable.get_acq_catalog(19387)
+    acqs = get_acq_catalog(19387)
     for acq, fid, offset in zip(acqs[:3], fids[:3], [90, 153, 155]):
         #                                           bad, bad, OK
         acq['halfw'] = 100

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -1,8 +1,10 @@
 import numpy as np
 
+from chandra_aca.transform import yagzag_to_pixels
+
 from ..fid import get_fid_positions, get_fid_catalog
 from ..acq import get_acq_catalog
-from chandra_aca.transform import yagzag_to_pixels
+from .test_common import OBS_INFO
 
 
 def test_get_fid_position():
@@ -93,7 +95,7 @@ def test_get_initial_catalog():
     # 20" + 20" + 10" + 100" + 4" = 154".  In this test 2, 4 should be
     # excluded but 5 should be OK.
 
-    acqs = get_acq_catalog(19387)
+    acqs = get_acq_catalog(**OBS_INFO[19387])
     for acq, fid, offset in zip(acqs[:3], fids[:3], [90, 153, 155]):
         #                                           bad, bad, OK
         acq['halfw'] = 100
@@ -101,7 +103,7 @@ def test_get_initial_catalog():
         acq['zang'] = fid['zang'] + offset
         acq['row'], acq['col'] = yagzag_to_pixels(acq['yang'], acq['zang'])
 
-    fids5 = get_fid_catalog(detector='ACIS-S', acqs=acqs)
+    fids5 = get_fid_catalog(acqs=acqs)
     exp = ['<FidTable length=6>',
            '  id    yang     zang     row     col     mag   spoiler_score slot',
            'int64 float64  float64  float64 float64 float64     int64     str3',


### PR DESCRIPTION
This should really be three separate PRs...

The new `AcqProbs` class is a pre-cursor to supporting integrated acq and fid probabilities.  I.e. a new dimension where the acq probabilities account for the current fid set in a hopefully-nice way.

Fixes #54