### PR TITLE
Include and exclude stars from catalog selection

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -357,8 +357,9 @@ class AcqTable(ACACatalogTable):
         # Accumulate indices and box sizes of candidate acq stars that meet
         # successively less stringent minimum p_acq.
         for min_p_acq in (0.75, 0.5, 0.25, 0.05):
-            # Updates acq_indices, box_sizes in place
-            self.select_best_p_acqs(cand_acqs, min_p_acq, acq_indices, box_sizes)
+            if len(acq_indices) < 8:
+                # Updates acq_indices, box_sizes in place
+                self.select_best_p_acqs(cand_acqs, min_p_acq, acq_indices, box_sizes)
 
             if len(acq_indices) == 8:
                 break

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -477,7 +477,7 @@ class AcqTable(ACACatalogTable):
         return p_safe, any_improved
 
     def optimize_catalog(self, verbose=False):
-        # If every acq star is specified as included, then no
+        # If every acq star is specified as included, then no optimization
         if all(acq['id'] in self.meta['include_ids'] for acq in self):
             return
 
@@ -513,7 +513,7 @@ class AcqTable(ACACatalogTable):
             idx = self.get_id_idx(acqs[idx_worst]['id'])
 
             self.log('Trying to use {} mag={:.2f} to replace idx={} with p_acq={:.3f}'
-                     .format(cand_id, cand_acq['mag'], idx, p_acqs[idx_worst], id=cand_id))
+                     .format(cand_id, cand_acq['mag'], idx, p_acqs[idx_worst]), id=cand_id)
 
             # Make a copy of the row (acq star) as a numpy void (structured array row)
             orig_acq = self[idx].as_void()

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -113,8 +113,11 @@ class ACACatalogTable(Table):
             assert self['id'][idx] == id
         except (KeyError, IndexError, AssertionError):
             self.make_index()
-            idx = self._id_index[id]
-            assert self['id'][idx] == id
+            try:
+                idx = self._id_index[id]
+                assert self['id'][idx] == id
+            except (KeyError, IndexError, AssertionError):
+                raise KeyError(f'{id} is not in table')
 
         return idx
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -1,3 +1,4 @@
+import warnings
 import pickle
 import inspect
 import time
@@ -436,9 +437,12 @@ class StarsTable(ACACatalogTable):
         """
         agasc_stars = []
         for agasc_id in agasc_ids:
-            star = agasc.get_star(agasc_id, date)
-            agasc_stars.append(star)
-
+            try:
+                star = agasc.get_star(agasc_id, date=date)
+            except Exception:
+                raise ValueError(f'failed to get AGASC ID={agasc_id}')
+            else:
+                agasc_stars.append(star)
         agasc_stars = Table(rows=agasc_stars, names=agasc_stars[0].colnames)
         return StarsTable.from_stars(att, stars=agasc_stars)
 

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -373,3 +373,15 @@ def test_make_report(tmpdir):
             assert np.isclose(val, val2)
         else:
             assert val == val2
+
+
+def test_cand_acqs_include_exclude():
+    obsid = 19387
+    # First is in nominal cand_acqs but not in acqs
+    include_ids = [37882776, 38276824, 37881560]
+    exclude_ids = [38280776]
+    acqs = get_acq_catalog(**OBS_INFO[obsid], optimize=False,
+                           include_ids=include_ids, exclude_ids=exclude_ids)
+    assert acqs.meta['include_ids'] == include_ids
+    assert acqs.meta['exclude_ids'] == exclude_ids
+    assert all(id_ in acqs.meta['cand_acqs']['id'] for id_ in include_ids)

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -432,7 +432,7 @@ def test_cand_acqs_include_exclude():
     acqs.meta['include_ids'] = []
     acqs.meta['include_halfws'] = []
 
-    # Finally, starting from the catalog chosen with the include/exclude
+    # Now starting from the catalog chosen with the include/exclude
     # constraints applied, remove those constraints and re-optimize.
     # This must come back to the original catalog of the 8 bright stars.
     del acqs['slot']
@@ -441,3 +441,13 @@ def test_cand_acqs_include_exclude():
     acqs.sort('idx')
     assert np.all(acqs['id'] == np.arange(1, 9))
     assert np.all(acqs['halfw'] == 160)
+
+    # Finally include all 8 stars
+    include_ids = [1, 3, 4, 5, 6, 7, 9, 11]
+    include_halfws = [60, 80, 100, 120, 140, 60, 80, 100]
+
+    acqs = get_acq_catalog(**STD_INFO, optimize=True, stars=stars,
+                           include_ids=include_ids, include_halfws=include_halfws)
+
+    assert acqs['id'].tolist() == include_ids
+    assert acqs['halfw'].tolist() == include_halfws


### PR DESCRIPTION
This allows for including and excluding stars from catalog selection.

The immediate use is for starcheck, where it could be used to force the entire catalog to be what is 
found in backstop.  @jeanconn - would this meet your requirements?  It will regenerate probabilities so that the `p_acq` needed in starcheck (the marginalized versions going forward) will be available as `acqs['p_acq']` after re-getting the catalog with 8 appropriate include stars set.  (I realize now we need a param for max acq stars to force a catalog with fewer than 8).

Closes #3 
Addresses #50