### PR TITLE
Stub to allow 2-element sequence for dither in acq and fid selection

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -86,14 +86,23 @@ def get_acq_catalog(obsid=0, att=None,
         if focus_offset is None:
             focus_offset = 0
 
-        # TO DO: deal with non-square dither pattern, esp. 8 x 64.
         dither_y_amp = obso.get('dither_y_amp')
         dither_z_amp = obso.get('dither_z_amp')
         if dither_y_amp is not None and dither_z_amp is not None:
-            dither = max(dither_y_amp, dither_z_amp)
+            dither = (dither_y_amp, dither_z_amp)
 
         if dither is None:
             dither = 20
+
+    # TO DO: fix this temporary stub put in for the 1.0 release.  This converts
+    # a 2-element dither (y, z) to a single value which is currently needed for acq
+    # selection.
+    try:
+        dither = max(dither[0], dither[1])
+    except TypeError:
+        # Catches only the case where dither is not subscriptable.  Anything else
+        # should raise.
+        pass
 
     acqs.log(f'getting dark cal image at date={date} t_ccd={t_ccd:.1f}')
     dark = get_dark_cal_image(date=date, select='before', t_ccd_ref=t_ccd)

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -38,7 +38,7 @@ def get_acq_catalog(obsid=0, att=None,
     :param man_angle: maneuver angle (deg)
     :param t_ccd: ACA CCD temperature (degC)
     :param date: date of acquisition (any DateTime-compatible format)
-    :param dither: dither size (float, arcsec)
+    :param dither: dither size (float or 2-element sequence (dither_y, dither_z), arcsec)
     :param detector: 'ACIS-S' | 'ACIS-I' | 'HRC-S' | 'HRC-I'
     :param sim_offset: SIM translation offset from nominal [steps] (default=0)
     :param focus_offset: SIM focus offset [steps] (default=0)

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -89,6 +89,16 @@ class FidTable(ACACatalogTable):
                 print_log = acqs.print_log
             self.acqs = acqs
 
+        # TO DO: fix this temporary stub put in for the 1.0 release.  This converts
+        # a 2-element dither (y, z) to a single value which is currently needed for acq
+        # selection.
+        try:
+            dither = max(dither[0], dither[1])
+        except TypeError:
+            # Catches only the case where dither is not subscriptable.  Anything else
+            # should raise.
+            pass
+
         super().__init__(data=data, print_log=print_log, **kwargs)
 
         self.meta.update({'detector': detector,

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -26,7 +26,8 @@ def get_fid_catalog(*, detector=None, focus_offset=0, sim_offset=0,
     :param sim_offset: SIM translation offset from nominal [steps] (default=0)
     :param acqs: AcqTable catalog.  Optional but needed for actual fid selection.
     :param stars: stars table.  Defaults to acqs.meta['stars'] if available.
-    :param dither: dither [arcsec].  Defaults to acqs.meta['dither'] if available.
+    :param dither: dither (float or 2-element sequence (dither_y, dither_z), [arcsec]
+                   Defaults to acqs.meta['dither'] if available.
     :param print_log: print log to stdout (default=False)
     """
     fids = FidTable(detector=detector, focus_offset=focus_offset,
@@ -68,7 +69,8 @@ class FidTable(ACACatalogTable):
         :param sim_offset: SIM translation offset from nominal [steps] (default=0)
         :param acqs: AcqTable catalog.  Optional but needed for actual fid selection.
         :param stars: stars table.  Defaults to acqs.meta['stars'] if available.
-        :param dither: dither [arcsec].  Defaults to acqs.meta['dither'] if available.
+        :param dither: dither (float or 2-element sequence (dither_y, dither_z), [arcsec]
+                       Defaults to acqs.meta['dither'] if available.
         :param print_log: print log to stdout (default=False)
         :param **kwargs: any other kwargs for Table init
         """

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -451,3 +451,19 @@ def test_cand_acqs_include_exclude():
 
     assert acqs['id'].tolist() == include_ids
     assert acqs['halfw'].tolist() == include_halfws
+
+
+def test_dither_as_sequence():
+    """
+    Test that calling get_acq_catalog with a 2-element sequence (dither_y, dither_z)
+    gives the expected response.  (Basically that it still returns a catalog).
+    """
+
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(size=1500, n_stars=8)
+    kwargs = STD_INFO.copy()
+    kwargs['dither'] = (8, 22)
+
+    acqs = get_acq_catalog(**kwargs, stars=stars)
+    assert len(acqs) == 8
+    assert acqs.meta['dither'] == 22  # Will be (8, 22) for 4.0

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -138,3 +138,13 @@ def test_fid_mult_spoilers():
     assert np.all(cand_fids['spoiler_score'] == [0, 0, 1, 4, 0, 0])
     assert len(cand_fids['spoilers'][2]) == 1
     assert cand_fids['spoilers'][2]['warn'][0] == 'yellow'
+
+
+def test_dither_as_sequence():
+    """
+    Test that calling get_acq_catalog with a 2-element sequence (dither_y, dither_z)
+    gives the expected response.  (Basically that it still returns a catalog).
+    """
+    fids = get_fid_catalog(detector='ACIS-S', dither=(8, 22))
+    assert len(fids) == 3
+    assert fids.meta['dither'] == 22  # Will be (8, 22) for release 4.0


### PR DESCRIPTION
This is a stub to provide API compliance with requirement to pass in a dither tuple (or any 2-element sequence) consisting of `(dither_y_amp, dither_z_amp)` in arcsec.