### PR TITLE
Add ACABox class and use 2-component dither in acq, fid selection

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -940,13 +940,11 @@ def calc_p_on_ccd(row, col, box_size):
 
     :param row: row coordinate of star (float)
     :param col: col coordinate of star (float)
-    :param box_size: box size (int)
+    :param box_size: box size (ACABox)
 
     :returns: probability the star is on usable part of CCD (float)
     """
     p_on_ccd = 1.0
-    half_width = box_size / 5  # half width of box in pixels
-    full_width = half_width * 2
 
     # Require that the readout box when candidate acq star is evaluated
     # by the PEA (via a normal 8x8 readout) is fully on the CCD usable area.
@@ -955,12 +953,13 @@ def calc_p_on_ccd(row, col, box_size):
     max_ccd_row = CHAR.max_ccd_row - 5
     max_ccd_col = CHAR.max_ccd_col - 4
 
-    for rc, max_rc in ((row, max_ccd_row),
-                       (col, max_ccd_col)):
+    for rc, max_rc, half_width in ((row, max_ccd_row, box_size.row),
+                                   (col, max_ccd_col, box_size.col)):
 
         # Pixel boundaries are symmetric so just take abs(row/col)
         rc1 = abs(rc) + half_width
 
+        full_width = half_width * 2
         pix_off_ccd = rc1 - max_rc
         if pix_off_ccd > 0:
             # Reduce p_on_ccd by fraction of pixels inside usable area.
@@ -1030,7 +1029,7 @@ class AcqProbs:
 
         # Probability star is in acq box (function of man_err and dither only)
         for man_err in CHAR.man_errs:
-            p_on_ccd = calc_p_on_ccd(acq['row'], acq['col'], box_size=man_err + dither.max())
+            p_on_ccd = calc_p_on_ccd(acq['row'], acq['col'], box_size=man_err + dither)
             self.p_on_ccd[man_err] = p_on_ccd
 
         # All together now!

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -96,6 +96,10 @@ class ACABox:
         return not self == other
 
     def __gt__(self, other):
+        """
+        Returns True if either component is larger.  This is somewhat
+        specific to how boxes are used in intruder processing.
+        """
         if not isinstance(other, ACABox):
             other = ACABox(other)
         return self.y > other.y or self.z > other.z

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -53,7 +53,7 @@ class ACABox:
         either a two-element sequence (y, z) or a scalar (which applies
         to both y and z.
 
-        :param dither: scalar or 2-element sequence (y, z), (arcsec, default=20)
+        :param size: scalar or 2-element sequence (y, z), (arcsec, default=20)
 
         """
         if isinstance(size, ACABox):

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -46,6 +46,53 @@ def to_python(val):
     return val
 
 
+class ACABox:
+    def __init__(self, size=None):
+        """
+        Class to represent a box half width amplitude.  Can be initialized with
+        either a two-element sequence (y, z) or a scalar (which applies
+        to both y and z.
+
+        :param dither: scalar or 2-element sequence (y, z), (arcsec, default=20)
+
+        """
+        if isinstance(size, ACABox):
+            self.y = size.y
+            self.z = size.z
+            return
+
+        try:
+            assert len(size) == 2
+        except TypeError:
+            # len(scalar) raises TypeError
+            if size is None:
+                size = 20
+            self.y = size
+            self.z = size
+        except AssertionError:
+            # Has a length but it is not 2
+            raise ValueError('size arg must be either a scalar or a two-element sequence')
+        else:
+            self.y = size[0]
+            self.z = size[1]
+
+    @property
+    def row(self):
+        return self.y / 5
+
+    @property
+    def col(self):
+        return self.z / 5
+
+    def max(self):
+        return max(self.y, self.z)
+
+    def __eq__(self, other):
+        if not isinstance(other, ACABox):
+            other = ACABox(other)
+        return self.y == other.y and self.z == other.z
+
+
 class ACACatalogTable(Table):
     """
     Base class for representing ACA catalogs in star selection.  This

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -92,6 +92,25 @@ class ACABox:
             other = ACABox(other)
         return self.y == other.y and self.z == other.z
 
+    def __ne__(self, other):
+        return not self == other
+
+    def __gt__(self, other):
+        if not isinstance(other, ACABox):
+            other = ACABox(other)
+        return self.y > other.y or self.z > other.z
+
+    def __add__(self, other):
+        if not isinstance(other, ACABox):
+            other = ACABox(other)
+        return ACABox((self.y + other.y, self.z + other.z))
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def __repr__(self):
+        return f'<ACABox y={self.y} z={self.z}>'
+
 
 class ACACatalogTable(Table):
     """

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -245,11 +245,11 @@ class FidTable(ACACatalogTable):
         :returns: True if ``fid`` could be within ``acq`` search box
         """
         spoiler_margin = (FID.spoiler_margin +
-                          self.acqs.meta['dither'].max() +
+                          self.acqs.meta['dither'] +
                           acq['halfw'])
         dy = np.abs(fid['yang'] - acq['yang'])
         dz = np.abs(fid['zang'] - acq['zang'])
-        return (dy < spoiler_margin and dz < spoiler_margin)
+        return (dy < spoiler_margin.y and dz < spoiler_margin.z)
 
     def get_fid_candidates(self):
         """
@@ -354,8 +354,8 @@ class FidTable(ACACatalogTable):
         dither = self.meta['dither']
 
         # Potential spoiler by position
-        spoil = ((np.abs(stars['yang'] - fid['yang']) < FID.spoiler_margin + dither.max()) &
-                 (np.abs(stars['zang'] - fid['zang']) < FID.spoiler_margin + dither.max()))
+        spoil = ((np.abs(stars['yang'] - fid['yang']) < FID.spoiler_margin + dither.y) &
+                 (np.abs(stars['zang'] - fid['zang']) < FID.spoiler_margin + dither.z))
 
         if not np.any(spoil):
             # Make an empty table with same columns

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -14,7 +14,7 @@ from chandra_aca.transform import yagzag_to_pixels
 from . import characteristics_fid as FID
 from . import characteristics as ACQ
 
-from .core import ACACatalogTable
+from .core import ACACatalogTable, ACABox
 
 
 def get_fid_catalog(*, detector=None, focus_offset=0, sim_offset=0,
@@ -92,7 +92,7 @@ class FidTable(ACACatalogTable):
         :param acqs: AcqTable catalog.  Optional but needed for actual fid selection.
         :param stars: stars table.  Defaults to acqs.meta['stars'] if available.
         :param dither: dither (float or 2-element sequence (dither_y, dither_z), [arcsec]
-                       Defaults to acqs.meta['dither'] if available.
+                       Defaults to acqs.meta['dither'] if available, or 20 otherwise.
         :param n_fid: number of desired fid lights
         :param print_log: print log to stdout (default=False)
         :param **kwargs: any other kwargs for Table init
@@ -112,9 +112,12 @@ class FidTable(ACACatalogTable):
                 focus_offset = acqs.meta['focus_offset']
             if print_log is None:
                 print_log = acqs.print_log
+
             self.acqs = acqs
 
-        # TO DO: fix this temporary stub put in for the 1.0 release.  This converts
+        if not isinstance(dither, ACABox):
+            dither = ACABox(dither)
+
         # a 2-element dither (y, z) to a single value which is currently needed for acq
         # selection.
         try:
@@ -242,7 +245,7 @@ class FidTable(ACACatalogTable):
         :returns: True if ``fid`` could be within ``acq`` search box
         """
         spoiler_margin = (FID.spoiler_margin +
-                          self.acqs.meta['dither'] +
+                          self.acqs.meta['dither'].max() +
                           acq['halfw'])
         dy = np.abs(fid['yang'] - acq['yang'])
         dz = np.abs(fid['zang'] - acq['zang'])
@@ -351,8 +354,8 @@ class FidTable(ACACatalogTable):
         dither = self.meta['dither']
 
         # Potential spoiler by position
-        spoil = ((np.abs(stars['yang'] - fid['yang']) < FID.spoiler_margin + dither) &
-                 (np.abs(stars['zang'] - fid['zang']) < FID.spoiler_margin + dither))
+        spoil = ((np.abs(stars['yang'] - fid['yang']) < FID.spoiler_margin + dither.max()) &
+                 (np.abs(stars['zang'] - fid['zang']) < FID.spoiler_margin + dither.max()))
 
         if not np.any(spoil):
             # Make an empty table with same columns

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -464,11 +464,12 @@ def plot_imposters(acq, dark, dither, vmin=100, vmax=2000,
     rc = img.shape[0] // 2 + 0.5
     cc = img.shape[1] // 2 + 0.5
     for hw in CHAR.p_man_errs['man_err_hi']:
-        hwp = (hw + dither.max()) / 5
-        patch = patches.Rectangle((rc - hwp, cc - hwp), hwp * 2, hwp * 2, edgecolor='r',
+        hwpr = hw / 5 + dither.row
+        hwpc = hw / 5 + dither.col
+        patch = patches.Rectangle((rc - hwpr, cc - hwpc), hwpr * 2, hwpc * 2, edgecolor='r',
                                   facecolor='none', lw=1, alpha=1)
         ax.add_patch(patch)
-        plt.text(rc - hwp + 1, cc - hwp + 1, f'{hw}"', color='y', fontweight='bold')
+        plt.text(rc - hwpr + 1, cc - hwpc + 1, f'{hw}"', color='y', fontweight='bold')
 
     # Hack to fix up ticks to have proper row/col coords.  There must be a
     # correct way to do this.

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -426,7 +426,7 @@ def plot_imposters(acq, dark, dither, vmin=100, vmax=2000,
     """
     Plot dark current, relevant boxes, imposters and spoilers.
     """
-    drc = int(np.max(CHAR.box_sizes) / 5 + 5 + dither / 5)
+    drc = int(np.max(CHAR.box_sizes) / 5 + 5 + dither.max() / 5)
 
     # Make an image of `dark` centered on acq row, col.  Use ACAImage
     # arithmetic to handle the corner case where row/col are near edge
@@ -464,7 +464,7 @@ def plot_imposters(acq, dark, dither, vmin=100, vmax=2000,
     rc = img.shape[0] // 2 + 0.5
     cc = img.shape[1] // 2 + 0.5
     for hw in CHAR.p_man_errs['man_err_hi']:
-        hwp = (hw + dither) / 5
+        hwp = (hw + dither.max()) / 5
         patch = patches.Rectangle((rc - hwp, cc - hwp), hwp * 2, hwp * 2, edgecolor='r',
                                   facecolor='none', lw=1, alpha=1)
         ax.add_patch(patch)

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -115,7 +115,7 @@ def test_get_image_props():
 def setup_get_imposter_stars(val):
     bgd = 40
     dark = np.full((100, 100), fill_value=bgd, dtype=float)
-    box_size = 6 * 5
+    box_size = ACABox(6 * 5)
     dark[30, 28] = val + bgd
     dark[32, 29] = val + bgd
     dark[30, 30] = val + bgd

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -238,22 +238,22 @@ def test_calc_p_on_ccd():
     max_ccd_col = CHAR.max_ccd_col - 4
 
     # Halfway off in both row and col, (1/4 of area remaining)
-    p_in_box = calc_p_on_ccd(max_ccd_row, max_ccd_col, 60)
+    p_in_box = calc_p_on_ccd(max_ccd_row, max_ccd_col, ACABox(60))
     assert np.allclose(p_in_box, 0.25)
 
-    p_in_box = calc_p_on_ccd(max_ccd_row, max_ccd_col, 120)
+    p_in_box = calc_p_on_ccd(max_ccd_row, max_ccd_col, ACABox(120))
     assert np.allclose(p_in_box, 0.25)
 
     # 3 of 8 pixels off in row (5/8 of area remaining)
-    p_in_box = calc_p_on_ccd(max_ccd_row - 1, 0, 20)
+    p_in_box = calc_p_on_ccd(max_ccd_row - 1, 0, ACABox(20))
     assert np.allclose(p_in_box, 0.625)
 
     # Same but for col
-    p_in_box = calc_p_on_ccd(0, max_ccd_col - 1, 20)
+    p_in_box = calc_p_on_ccd(0, max_ccd_col - 1, ACABox(20))
     assert np.allclose(p_in_box, 0.625)
 
     # Same but for a negative col number
-    p_in_box = calc_p_on_ccd(0, -(max_ccd_col - 1), 20)
+    p_in_box = calc_p_on_ccd(0, -(max_ccd_col - 1), ACABox(20))
     assert np.allclose(p_in_box, 0.625)
 
 

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -456,7 +456,13 @@ def test_box_strategy_20603():
 
 
 def test_make_report(tmpdir):
+    """
+    Test making an acquisition report.  Use a big-box dither here
+    to test handling of that in report (after passing through pickle).
+    """
     obsid = 19387
+    kwargs = OBS_INFO[obsid].copy()
+    kwargs['dither'] = (8, 64)
     acqs = get_acq_catalog(**OBS_INFO[obsid])
 
     tmpdir = Path(tmpdir)

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -14,6 +14,7 @@ from ..acq import (get_p_man_err, bin2x2, CHAR,
                    AcqTable, calc_p_on_ccd,
                    get_acq_catalog,
                    )
+from ..core import ACABox
 from .test_common import OBS_INFO, STD_INFO
 
 TEST_DATE = '2018:144'  # Fixed date for doing tests
@@ -192,7 +193,7 @@ def test_calc_p_brightest_same_bright():
     dark_imp = add_imposter(dark, acq, dyang=-105, dzang=-105, dmag=0.0)
     stars_sp = add_spoiler(stars, acq, dyang=65, dzang=65, dmag=0.0, mag_err=mag_err)
     stars_sp = add_spoiler(stars_sp, acq, dyang=85, dzang=0, dmag=0.0, mag_err=mag_err)
-    probs = [calc_p_brightest(acq, box_size, stars_sp, dark_imp, dither=0, bgd=bgd)
+    probs = [calc_p_brightest(acq, box_size, stars_sp, dark_imp, dither=ACABox(0), bgd=bgd)
              for box_size in CHAR.box_sizes]
 
     #  Box size:                160   140   120    100   80   60  arcsec
@@ -211,21 +212,21 @@ def test_calc_p_brightest_1mag_brighter():
     # Bright spoiler at 65 arcsec
     acq = get_test_cand_acqs()[0]
     stars_sp = add_spoiler(stars, acq, dyang=65, dzang=65, dmag=-1.0)
-    probs = [calc_p_brightest(acq, box_size, stars_sp, dark, dither=0, bgd=bgd)
+    probs = [calc_p_brightest(acq, box_size, stars_sp, dark, dither=ACABox(0), bgd=bgd)
              for box_size in box_sizes]
     assert np.allclose(probs, [0.0, 1.0], rtol=0, atol=0.001)
 
     # Comparable spoiler at 65 arcsec (within mag_err)
     acq = get_test_cand_acqs()[0]
     stars_sp = add_spoiler(stars, acq, dyang=65, dzang=65, dmag=-1.0, mag_err=1.0)
-    probs = [calc_p_brightest(acq, box_size, stars_sp, dark, dither=0, bgd=bgd)
+    probs = [calc_p_brightest(acq, box_size, stars_sp, dark, dither=ACABox(0), bgd=bgd)
              for box_size in box_sizes]
     assert np.allclose(probs, [0.158974, 1.0], rtol=0, atol=0.01)
 
     # Bright imposter at 85 arcsec
     acq = get_test_cand_acqs()[0]
     dark_imp = add_imposter(dark, acq, dyang=-85, dzang=-85, dmag=-1.0)
-    probs = [calc_p_brightest(acq, box_size, stars, dark_imp, dither=0, bgd=bgd)
+    probs = [calc_p_brightest(acq, box_size, stars, dark_imp, dither=ACABox(0), bgd=bgd)
              for box_size in box_sizes]
     assert np.allclose(probs, [0.0, 1.0], rtol=0, atol=0.001)
 
@@ -465,7 +466,7 @@ def test_dither_as_sequence():
 
     acqs = get_acq_catalog(**kwargs, stars=stars)
     assert len(acqs) == 8
-    assert acqs.meta['dither'] == 22  # Will be (8, 22) for 4.0
+    assert acqs.meta['dither'] == (8, 22)
 
 
 def test_n_acq():

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -1,0 +1,90 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+
+from ..core import ACABox
+
+
+def test_box_init():
+    """ACABox initialization functionality"""
+    box = ACABox()
+    assert box.y == 20
+    assert box.z == 20
+
+    box = ACABox(None)
+    assert box.y == 20
+    assert box.z == 20
+
+    box = ACABox((15, 10))
+    assert box.y == 15
+    assert box.z == 10
+
+    box = ACABox([15, 10])
+    assert box.y == 15
+    assert box.z == 10
+
+    box2 = ACABox(box)
+    assert box2.y == 15
+    assert box2.z == 10
+
+    with pytest.raises(ValueError) as err:
+        ACABox([1, 2, 3])
+        assert 'size arg must be' in str(err)
+
+
+def test_box_row_col_max():
+    """ACABox row, col properties and max() method"""
+    box = ACABox((15, 10))
+    assert box.row == 3
+    assert box.col == 2
+    assert box.max() == 15
+
+
+def test_box_eq():
+    """ACABox equality and inequality"""
+    dither1 = (15, 10)
+    dither3 = (16, 10)
+    box1 = ACABox(dither1)
+    box2 = ACABox(dither1)
+    box3 = ACABox(dither3)
+
+    # ACABox to ACABox test
+    assert box1 == box2
+    assert box1 != box3
+
+    # Test against left and right sides that need conversion to ACABox first
+    assert dither1 == box1
+    assert dither1 != box3
+    assert box1 == dither1
+    assert box3 != dither1
+
+
+def test_box_add():
+    """ACABox left and right addition"""
+    box1 = ACABox((10, 15))
+
+    box2 = box1 + 5
+    assert box2 == (15, 20)
+
+    box2 = 5 + box1
+    assert box2 == (15, 20)
+
+    box2 = (5, 10) + box1
+    assert box2 == (15, 25)
+
+    box2 = box1 + (5, 10)
+    assert box2 == (15, 25)
+
+
+def test_box_greater():
+    """ACABox 'greater than' comparison"""
+    box1 = ACABox((10, 15))
+
+    # True if either component of box1 is bigger than the test value
+    assert box1 > (9.9, 14.9)
+    assert box1 > (9.9, 15)
+    assert box1 > (10, 14.9)
+
+    assert not box1 > (10, 15)
+    assert not box1 > box1
+    assert not box1 > (11, 16)

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -158,4 +158,4 @@ def test_dither_as_sequence():
     """
     fids = get_fid_catalog(detector='ACIS-S', dither=(8, 22))
     assert len(fids) == 3
-    assert fids.meta['dither'] == 22  # Will be (8, 22) for release 4.0
+    assert fids.meta['dither'] == (8, 22)


### PR DESCRIPTION
This adds a class `ACABox` that can be used to hold a dither.  Depending on how the code goes I think it might hold something that isn't strictly a dither, so it has a generic name.

Status:
- [x] Pass guide tests
- [x] Pass acq and fid tests using a stub `max()` method that gives the same scalar currently used in the code
- [x] Fix acq and fid code to use actual `y` and `z` component values
- [x] Write new tests (e.g. large dither obs) with different `y` and `z` values.

Closes #56 