### PR TITLE
Make get_acq_catalog work with no candidates

### DIFF
--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -508,3 +508,17 @@ def test_warnings():
     stars.add_fake_constellation(n_stars=6)
     acqs = get_acq_catalog(**STD_INFO, stars=stars, n_acq=8, optimize=False)
     assert acqs.warnings == ['WARNING: Selected only 6 acq stars versus requested 8']
+
+
+def test_no_candidates():
+    """
+    Test that get_acq_catalog returns a well-formed but zero-length table for
+    a star field with no acceptable candidates.
+    """
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(mag=13.0, n_stars=2)
+    acqs = get_acq_catalog(**STD_INFO, stars=stars)
+
+    assert len(acqs) == 0
+    assert 'id' in acqs.colnames
+    assert 'halfw' in acqs.colnames


### PR DESCRIPTION
This is part of an alternate solution for #89.

The idea is to make each of the three get_*_catalog functions always return a well-formed table, or else raise an exception.

Note the workaround for a "feature" of astropy Table.  This is the same thing that comes up if you make a `stars` table like in the new test here and feed it to `get_guide_catalog`.
```
In [1]: astro
astropy=3.0.3

In [2]: t = Table()

In [3]: t['a'] = []  # Zero-length table now

In [4]: t['b'] = 1
TypeError: len() of unsized object
```
