### PR TITLE
Unify code, add MetaAttribute descriptor, and fix fid select to use relevant dither

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -53,7 +53,7 @@ def get_acq_catalog(obsid=0, **kwargs):
     # Make an empty AcqTable object, mostly for logging.  It gets populated
     # after selecting initial an inital catalog of potential acq stars.
     acqs = AcqTable()
-    acqs.set_kwargs(obsid=obsid, **kwargs)
+    acqs.set_attrs_from_kwargs(obsid=obsid, **kwargs)
     acqs.set_stars()
 
     acqs.log(f'getting dark cal image at date={acqs.date} t_ccd={acqs.t_ccd:.1f}')

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -15,7 +15,7 @@ from chandra_aca.transform import (pixels_to_yagzag, mag_to_count_rate)
 from mica.archive.aca_dark.dark_cal import get_dark_cal_image
 
 from . import characteristics as CHAR
-from .core import (get_mag_std, StarsTable, ACACatalogTable, bin2x2,
+from .core import (get_mag_std, ACACatalogTable, bin2x2,
                    get_image_props, pea_reject_image, ACABox,
                    MetaAttribute)
 
@@ -62,7 +62,7 @@ def get_acq_catalog(obsid=0, **kwargs):
     # Probability of man_err for this observation with a given man_angle.  Used
     # for marginalizing probabilities over different man_errs.
     acqs.p_man_errs = np.array([get_p_man_err(man_err, acqs.man_angle)
-                                        for man_err in CHAR.man_errs])
+                                for man_err in CHAR.man_errs])
 
     acqs.cand_acqs, acqs.bad_stars = acqs.get_acq_candidates(acqs.stars)
 

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -54,6 +54,7 @@ def get_acq_catalog(obsid=0, **kwargs):
     # after selecting initial an inital catalog of potential acq stars.
     acqs = AcqTable()
     acqs.set_kwargs(obsid=obsid, **kwargs)
+    acqs.set_stars()
 
     acqs.log(f'getting dark cal image at date={acqs.date} t_ccd={acqs.t_ccd:.1f}')
     acqs.dark = get_dark_cal_image(date=acqs.date, select='before', t_ccd_ref=acqs.t_ccd)
@@ -62,11 +63,6 @@ def get_acq_catalog(obsid=0, **kwargs):
     # for marginalizing probabilities over different man_errs.
     acqs.p_man_errs = np.array([get_p_man_err(man_err, acqs.man_angle)
                                         for man_err in CHAR.man_errs])
-
-    if acqs.stars is None:
-        acqs.stars = StarsTable.from_agasc(acqs.att, date=acqs.date, logger=acqs.log)
-    else:
-        acqs.stars = StarsTable.from_stars(acqs.att, acqs.stars, logger=acqs.log)
 
     acqs.cand_acqs, acqs.bad_stars = acqs.get_acq_candidates(acqs.stars)
 

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -123,6 +123,9 @@ class AcqTable(ACACatalogTable):
     # Required attributes
     required_attrs = ('att', 'man_angle', 't_ccd_acq', 'date', 'dither_acq')
 
+    optimize = MetaAttribute(default=True)
+    verbose = MetaAttribute(default=False)
+
     p_man_errs = MetaAttribute(is_kwarg=False)
     cand_acqs = MetaAttribute(is_kwarg=False)
     p_safe = MetaAttribute(is_kwarg=False)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -247,6 +247,22 @@ class ACACatalogTable(Table):
             if not isinstance(dither, ACABox):
                 setattr(self, dither_attr, ACABox(dither))
 
+    def set_stars(self, acqs=None):
+        """Set the object ``stars`` attribute to an appropriate StarsTable object.
+
+        If ``acqs`` is defined that will be a previously computed AcqTable with
+        ``stars`` already available, so use that.
+
+        :param acqs: AcqTable for same observation
+        """
+        if acqs is None:
+            if self.stars is None:
+                self.stars = StarsTable.from_agasc(self.att, date=self.date, logger=self.log)
+            else:
+                self.stars = StarsTable.from_stars(self.att, self.stars, logger=self.log)
+        else:
+            self.stars = acqs.stars
+
     @property
     def dither(self):
         super().__getattr__(self, 'dither')

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -159,6 +159,8 @@ class ACACatalogTable(Table):
     # Catalog attributes, gets set in MetaAttribute
     allowed_kwargs = set(['dither', 't_ccd'])
 
+    required_attrs = ('dither_acq', 'dither_guide', 'date')
+
     obsid = MetaAttribute(default=0)
     att = MetaAttribute()
     n_acq = MetaAttribute(default=8)
@@ -243,6 +245,13 @@ class ACACatalogTable(Table):
                     dither_z_amp = obso.get('dither_z_amp')
                     if dither_y_amp is not None and dither_z_amp is not None:
                         setattr(self, dither_attr, ACABox((dither_y_amp, dither_z_amp)))
+
+                        # Special rule for handling big dither from mica.starcheck,
+                        # which does not yet know about dither_acq vs. dither_guide.
+                        # Use the most common dither size for ACIS / HRC.
+                        if dither_attr == 'dither_acq' and self.dither_acq.max() > 30:
+                            dither = 8 if self.detector.startswith('ACIS') else 20
+                            self.dither_acq = ACABox(dither)
 
         for dither_attr in ('dither_acq', 'dither_guide'):
             dither = getattr(self, dither_attr)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -199,7 +199,7 @@ class ACACatalogTable(Table):
         for name in ('ra', 'dec', 'RA_PMCORR', 'DEC_PMCORR'):
             self._default_formats[name] = '.6f'
 
-    def set_kwargs(self, **kwargs):
+    def set_attrs_from_kwargs(self, **kwargs):
         for name, val in kwargs.items():
             if name in self.allowed_kwargs:
                 setattr(self, name, val)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -269,7 +269,7 @@ class ACACatalogTable(Table):
 
     @property
     def dither(self):
-        super().__getattr__(self, 'dither')
+        return None
 
     @dither.setter
     def dither(self, value):
@@ -278,7 +278,7 @@ class ACACatalogTable(Table):
 
     @property
     def t_ccd(self):
-        super().__getattr__(self, 't_ccd')
+        return None
 
     @t_ccd.setter
     def t_ccd(self, value):

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -177,9 +177,7 @@ class ACACatalogTable(Table):
     include_ids = MetaAttribute(default=[])
     include_halfws = MetaAttribute(default=[])
     exclude_ids = MetaAttribute(default=[])
-    optimize = MetaAttribute()
-    verbose = MetaAttribute()
-    print_log = MetaAttribute()
+    print_log = MetaAttribute(default=False)
 
     def __init__(self, data=None, **kwargs):
         super().__init__(data=data, **kwargs)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -162,7 +162,7 @@ class ACACatalogTable(Table):
     obsid = MetaAttribute(default=0)
     att = MetaAttribute()
     n_acq = MetaAttribute(default=8)
-    n_guide = MetaAttribute(default=8)
+    n_guide = MetaAttribute()
     n_fid = MetaAttribute(default=3)
     man_angle = MetaAttribute()
     t_ccd_acq = MetaAttribute()
@@ -225,7 +225,7 @@ class ACACatalogTable(Table):
             if self.date is None:
                 self.date = obso['mp_starcat_time']
             if self.t_ccd is None:
-                self.t_ccd = obs['pred_temp']
+                self.t_ccd = obs.get('pred_temp', -15.0)
             if self.man_angle is None:
                 self.man_angle = obs['manvr']['angle_deg'][0]
             if self.detector is None:
@@ -234,6 +234,10 @@ class ACACatalogTable(Table):
                 self.sim_offset = obso['sim_z_offset_steps']
             if self.focus_offset is None:
                 self.focus_offset = 0
+
+            if self.n_guide is None:
+                fid_or_mon = (obs['cat']['type'] == 'FID') | (obs['cat']['type'] == 'MON')
+                self.n_guide = 8 - np.count_nonzero(fid_or_mon)
 
             for dither_attr in ('dither_acq', 'dither_guide'):
                 if getattr(self, dither_attr) is None:

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -14,7 +14,7 @@ from chandra_aca.transform import yagzag_to_pixels
 from . import characteristics_fid as FID
 from . import characteristics as ACQ
 
-from .core import ACACatalogTable, ACABox
+from .core import ACACatalogTable
 
 
 def get_fid_catalog(obsid=0, **kwargs):

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -35,8 +35,8 @@ def get_fid_catalog(obsid=0, **kwargs):
     :param sim_offset: SIM translation offset from nominal [steps] (default=0)
     :param acqs: AcqTable catalog.  Optional but needed for actual fid selection.
     :param stars: stars table.  Defaults to acqs.stars if available.
-    :param dither: dither (float or 2-element sequence (dither_y, dither_z), [arcsec]
-                   Defaults to acqs.dither if available.
+    :param dither_acq: acq dither size (2-element sequence (y, z), arcsec)
+    :param dither_guide: guide dither size (2-element sequence (y, z), arcsec)
     :param n_fid: number of desired fid lights
     :param print_log: print log to stdout (default=False)
 

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -44,6 +44,7 @@ def get_fid_catalog(obsid=0, **kwargs):
     """
     fids = FidTable()
     fids.set_kwargs(obsid=obsid, **kwargs)
+    fids.set_stars(acqs=fids.acqs)
 
     fids.cand_fids = fids.get_fid_candidates()
 

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -43,7 +43,7 @@ def get_fid_catalog(obsid=0, **kwargs):
     :returns: fid catalog (FidTable)
     """
     fids = FidTable()
-    fids.set_kwargs(obsid=obsid, **kwargs)
+    fids.set_attrs_from_kwargs(obsid=obsid, **kwargs)
     fids.set_stars(acqs=fids.acqs)
 
     fids.cand_fids = fids.get_fid_candidates()

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -17,9 +17,7 @@ from . import characteristics as ACQ
 from .core import ACACatalogTable, ACABox
 
 
-def get_fid_catalog(*, detector=None, focus_offset=0, sim_offset=0,
-                    acqs=None, stars=None, dither=None, n_fid=3,
-                    print_log=None):
+def get_fid_catalog(obsid=0, **kwargs):
     """
     Get a catalog of fid lights.
 
@@ -36,19 +34,18 @@ def get_fid_catalog(*, detector=None, focus_offset=0, sim_offset=0,
     :param focus_offset: SIM focus offset [steps] (default=0)
     :param sim_offset: SIM translation offset from nominal [steps] (default=0)
     :param acqs: AcqTable catalog.  Optional but needed for actual fid selection.
-    :param stars: stars table.  Defaults to acqs.meta['stars'] if available.
+    :param stars: stars table.  Defaults to acqs.stars if available.
     :param dither: dither (float or 2-element sequence (dither_y, dither_z), [arcsec]
-                   Defaults to acqs.meta['dither'] if available.
+                   Defaults to acqs.dither if available.
     :param n_fid: number of desired fid lights
     :param print_log: print log to stdout (default=False)
 
     :returns: fid catalog (FidTable)
     """
-    fids = FidTable(detector=detector, focus_offset=focus_offset,
-                    sim_offset=sim_offset, acqs=acqs, stars=stars,
-                    dither=dither, n_fid=n_fid, print_log=print_log)
+    fids = FidTable()
+    fids.set_kwargs(obsid=obsid, **kwargs)
 
-    fids.meta['cand_fids'] = fids.get_fid_candidates()
+    fids.cand_fids = fids.get_fid_candidates()
 
     # Set initial fid catalog if possible to a set for which no field stars
     # spoiler any of the fid lights and no fid lights is a search spoilers for
@@ -61,11 +58,11 @@ def get_fid_catalog(*, detector=None, focus_offset=0, sim_offset=0,
 
     # TO DO: remove temporary stub to simply clip the number of returned
     # fids to n_fid
-    if len(fids) > n_fid:
-        fids = fids[:n_fid]
+    if len(fids) > fids.n_fid:
+        fids = fids[:fids.n_fid]
 
     # Set fid thumbs_up if fids has the number of requested fid lights
-    fids.thumbs_up = len(fids) == n_fid
+    fids.thumbs_up = len(fids) == fids.n_fid
 
     return fids
 
@@ -79,63 +76,11 @@ class FidTable(ACACatalogTable):
     # (e.g. `obs19387/fids.yaml`).
     name = 'fids'
 
-    def __init__(self, data=None, *,  # Keyword only from here
-                 detector=None, focus_offset=0, sim_offset=0,
-                 acqs=None, stars=None, dither=None, n_fid=3,
-                 print_log=None, **kwargs):
-        """
-        Table of fid lights, with methods for selection.
+    allowed_kwargs = ACACatalogTable.allowed_kwargs | set(['acqs'])
 
-        :param detector: 'ACIS-S' | 'ACIS-I' | 'HRC-S' | 'HRC-I'
-        :param focus_offset: SIM focus offset [steps] (default=0)
-        :param sim_offset: SIM translation offset from nominal [steps] (default=0)
-        :param acqs: AcqTable catalog.  Optional but needed for actual fid selection.
-        :param stars: stars table.  Defaults to acqs.meta['stars'] if available.
-        :param dither: dither (float or 2-element sequence (dither_y, dither_z), [arcsec]
-                       Defaults to acqs.meta['dither'] if available, or 20 otherwise.
-        :param n_fid: number of desired fid lights
-        :param print_log: print log to stdout (default=False)
-        :param **kwargs: any other kwargs for Table init
-        """
-        # If acqs (acq catalog) supplied then make a weak reference since that
-        # may have a ref to this fid catalog.
-        if acqs is not None:
-            if stars is None:
-                stars = acqs.meta['stars']
-            if dither is None:
-                dither = acqs.meta['dither']
-            if detector is None:
-                detector = acqs.meta['detector']
-            if sim_offset is None:
-                sim_offset = acqs.meta['sim_offset']
-            if focus_offset is None:
-                focus_offset = acqs.meta['focus_offset']
-            if print_log is None:
-                print_log = acqs.print_log
-
-            self.acqs = acqs
-
-        if not isinstance(dither, ACABox):
-            dither = ACABox(dither)
-
-        # a 2-element dither (y, z) to a single value which is currently needed for acq
-        # selection.
-        try:
-            dither = max(dither[0], dither[1])
-        except TypeError:
-            # Catches only the case where dither is not subscriptable.  Anything else
-            # should raise.
-            pass
-
-        super().__init__(data=data, print_log=print_log, **kwargs)
-
-        self.meta.update({'detector': detector,
-                          'focus_offset': focus_offset,
-                          'sim_offset': sim_offset,
-                          'acqs': acqs,
-                          'dither': dither,
-                          'n_fid': n_fid,
-                          'stars': stars})
+    required_attrs = ('att', 'detector', 'sim_offset', 'focus_offset',
+                      't_ccd_acq', 't_ccd_guide', 'date',
+                      'dither_acq', 'dither_guide')
 
     @property
     def acqs(self):
@@ -158,12 +103,12 @@ class FidTable(ACACatalogTable):
 
             # Add slot to cand_fids table, putting in '...' if not selected as acq.
             # This is for convenience in downstream reporting or introspection.
-            cand_fids = self.meta['cand_fids']
+            cand_fids = self.cand_fids
             slots = [str(self.get_id(fid['id'])['slot']) if fid['id'] in self['id'] else not_sel
                      for fid in cand_fids]
             cand_fids['slot'] = slots
         else:
-            self.meta['cand_fids']['slot'] = '...'
+            self.cand_fids['slot'] = '...'
 
     def set_initial_catalog(self):
         """Set initial fid catalog (fid set) if possible to the first set which is
@@ -178,13 +123,13 @@ class FidTable(ACACatalogTable):
         """
         # Start by getting the id of every fid that has a zero spoiler score,
         # meaning no star spoils the fid as set previously in get_initial_candidates.
-        cand_fids = self.meta['cand_fids']
+        cand_fids = self.cand_fids
         cand_fids_set = set(fid['id'] for fid in cand_fids if fid['spoiler_score'] == 0)
 
         # Get list of fid_sets that are consistent with candidate fids. These
         # fid sets are the combinations of 3 (or 2) fid lights in preferred
         # order.
-        fid_sets = FID.fid_sets[self.meta['detector']]
+        fid_sets = FID.fid_sets[self.detector]
         ok_fid_sets = [fid_set for fid_set in fid_sets if fid_set <= cand_fids_set]
 
         # If no fid_sets are possible, return a zero-length table with correct columns
@@ -245,7 +190,7 @@ class FidTable(ACACatalogTable):
         :returns: True if ``fid`` could be within ``acq`` search box
         """
         spoiler_margin = (FID.spoiler_margin +
-                          self.acqs.meta['dither'] +
+                          self.dither_acq +
                           acq['halfw'])
         dy = np.abs(fid['yang'] - acq['yang'])
         dz = np.abs(fid['zang'] - acq['zang'])
@@ -258,11 +203,11 @@ class FidTable(ACACatalogTable):
 
         This also finds fid spoiler stars and computes the spoiler_score.
 
-        Result is updating self.meta['cand_fids'].
+        Result is updating self.cand_fids.
         """
-        yang, zang = get_fid_positions(self.meta['detector'],
-                                       self.meta['focus_offset'],
-                                       self.meta['sim_offset'])
+        yang, zang = get_fid_positions(self.detector,
+                                       self.focus_offset,
+                                       self.sim_offset)
         row, col = yagzag_to_pixels(yang, zang, allow_bad=True)
         ids = np.arange(len(yang), dtype=np.int64) + 1  # E.g. 1 to 6 for ACIS
 
@@ -281,7 +226,7 @@ class FidTable(ACACatalogTable):
         cand_fids['spoiler_score'] = np.int64(0)
 
         # If stars are available then find stars that are bad for fid.
-        if self.meta['stars']:
+        if self.stars:
             for fid in cand_fids:
                 self.set_spoilers_score(fid)
 
@@ -350,8 +295,8 @@ class FidTable(ACACatalogTable):
 
         :param fid: fid light (FidTable Row)
         """
-        stars = self.meta['stars'][ACQ.spoiler_star_cols]
-        dither = self.meta['dither']
+        stars = self.stars[ACQ.spoiler_star_cols]
+        dither = self.dither_guide
 
         # Potential spoiler by position
         spoil = ((np.abs(stars['yang'] - fid['yang']) < FID.spoiler_margin + dither.y) &

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -11,13 +11,12 @@ from chandra_aca.star_probs import guide_count
 from . import characteristics as CHAR
 from . import characteristics_guide as GUIDE_CHAR
 
-from .core import StarsTable, bin2x2, ACACatalogTable, ACABox
+from .core import StarsTable, bin2x2, ACACatalogTable, ACABox, MetaAttribute
 
 CCD = GUIDE_CHAR.CCD
 
 
-def get_guide_catalog(obsid=0, att=None, date=None, t_ccd=None, dither=None, n_guide=None,
-                      stars=None, dark=None, print_log=False):
+def get_guide_catalog(obsid=0, **kwargs):
     """
     Get a catalog of guide stars
 
@@ -38,66 +37,20 @@ def get_guide_catalog(obsid=0, att=None, date=None, t_ccd=None, dither=None, n_g
     :returns: GuideTable of acquisition stars
     """
 
-    guides = GuideTable(print_log=print_log)
+    guides = GuideTable()
+    guides.set_kwargs(obsid=obsid, **kwargs)
+    guides.set_stars()
 
-    # If an explicit obsid is not provided to all getting parameters via mica
-    # then all other params must be supplied.
-    all_pars = all(x is not None for x in (att, t_ccd, date, dither))
-    if obsid == 0 and not all_pars:
-        raise ValueError('if `obsid` not supplied then all other params are required')
-
-    # If not all params supplied then get via mica for the obsid.
-    if not all_pars:
-        from mica.starcheck import get_starcheck_catalog
-        guides.log(f'getting starcheck catalog for obsid {obsid}')
-
-        obs = get_starcheck_catalog(obsid)
-        obso = obs['obs']
-
-        if att is None:
-            att = [obso['point_ra'], obso['point_dec'], obso['point_roll']]
-        if date is None:
-            date = obso['mp_starcat_time']
-        if t_ccd is None:
-            t_ccd = obs.get('pred_temp') or -15
-
-        dither_y_amp = obso.get('dither_y_amp')
-        dither_z_amp = obso.get('dither_z_amp')
-        if dither_y_amp is not None and dither_z_amp is not None:
-            dither = ACABox((dither_y_amp, dither_z_amp))
-
-        if n_guide is None:
-            cat = obs['cat']
-            n_guide = 8 - np.count_nonzero((cat['type'] == 'FID') | (cat['type'] == 'MON'))
-
-    if not isinstance(dither, ACABox):
-        dither = ACABox(dither)
-
-    if dark is None:
+    if guides.dark is None:
         from mica.archive.aca_dark import get_dark_cal_image
-        guides.log(f'getting dark cal image at date={date} t_ccd={t_ccd:.1f}')
-        dark = get_dark_cal_image(date=date, select='before', t_ccd_ref=t_ccd, aca_image=True)
+        guides.log(f'getting dark cal image at date={guides.date} t_ccd={guides.t_ccd:.1f}')
+        guides.dark = get_dark_cal_image(date=guides.date, select='before',
+                                         t_ccd_ref=guides.t_ccd, aca_image=True)
     else:
         guides.log('Using supplied dark map (ignores t_ccd)')
 
-    if stars is None:
-        stars = StarsTable.from_agasc(att, date=date, logger=guides.log)
-    else:
-        stars = StarsTable.from_stars(att, stars, logger=guides.log)
-
-    # Update the meta with all the useful parameters
-    guides.meta = {'obsid': obsid,
-                   'att': att,
-                   'date': date,
-                   't_ccd': t_ccd,
-                   'dither': dither,
-                   'stars': stars,
-                   'dark': dark,
-                   'n_guide': n_guide}
-
     # Do a first cut of the stars to get a set of reasonable candidates
-    cand_guides = guides.get_initial_guide_candidates()
-    guides.meta.update({'cand_guides': cand_guides})
+    guides.cand_guides = guides.get_initial_guide_candidates()
 
     # Run through search stages to select stars
     selected = guides.run_search_stages()
@@ -106,12 +59,12 @@ def get_guide_catalog(obsid=0, att=None, date=None, t_ccd=None, dither=None, n_g
     for name, col in selected.columns.items():
         guides[name] = col
 
-    if len(guides) < n_guide:
-        guides.log(f'Selected only {len(guides)} guide stars versus requested {n_guide}',
+    if len(guides) < guides.n_guide:
+        guides.log(f'Selected only {len(guides)} guide stars versus requested {guides.n_guide}',
                    warning=True)
 
     # Evaluate guide catalog quality for thumbs_up
-    count = guide_count(guides['mag'], t_ccd)
+    count = guide_count(guides['mag'], guides.t_ccd)
     guides.thumbs_up = count >= GUIDE_CHAR.min_guide_count
 
     return guides
@@ -128,12 +81,34 @@ class GuideTable(ACACatalogTable):
     # (e.g. `obs19387/guide.yaml`).
     name = 'guide'
 
+    # Required attributes
+    required_attrs = ('att', 't_ccd_guide', 'date', 'dither_guide')
+
+    dark = MetaAttribute()
+    cand_guides = MetaAttribute(is_kwarg=False)
+
+    @property
+    def t_ccd(self):
+        return self.t_ccd_guide
+
+    @t_ccd.setter
+    def t_ccd(self, value):
+        self.t_ccd_guide = value
+
+    @property
+    def dither(self):
+        return self.dither_guide
+
+    @dither.setter
+    def dither(self, value):
+        self.dither_guide = value
+
     def run_search_stages(self):
         """
         Run through search stages to select stars with priority given to "better"
         stars in the stages.
         """
-        cand_guides = self.meta['cand_guides']
+        cand_guides = self.cand_guides
         self.log("Starting search stages")
         if len(cand_guides) == 0:
             self.log("There are no candidates to check in stages.  Exiting")
@@ -141,7 +116,7 @@ class GuideTable(ACACatalogTable):
             # cand_guides as the 'selected' stars.
             return cand_guides
         cand_guides['stage'] = -1
-        n_guide = self.meta['n_guide']
+        n_guide = self.n_guide
         for idx, stage in enumerate(GUIDE_CHAR.stages, 1):
             already_selected = np.count_nonzero(cand_guides['stage'] != -1)
 
@@ -158,10 +133,10 @@ class GuideTable(ACACatalogTable):
         self.log('Done with search stages')
         selected = cand_guides[cand_guides['stage'] != -1]
         selected.sort(['stage', 'mag'])
-        if len(selected) >= n_guide:
+        if len(selected) >= self.n_guide:
             return selected[0:n_guide]
-        if len(selected) < n_guide:
-            self.log(f'Could not find {n_guide} candidates after all search stages')
+        if len(selected) < self.n_guide:
+            self.log(f'Could not find {self.n_guide} candidates after all search stages')
             return selected
 
     def search_stage(self, stage):
@@ -176,9 +151,9 @@ class GuideTable(ACACatalogTable):
         :returns: bool mask of the length of self.meta.cand_guides
         """
 
-        cand_guides = self.meta['cand_guides']
-        stars = self.meta['stars']
-        dark = self.meta['dark']
+        cand_guides = self.cand_guides
+        stars = self.stars
+        dark = self.dark
         ok = np.ones(len(cand_guides)).astype(bool)
 
         # Adopt the SAUSAGE convention of a bit array for errors
@@ -239,8 +214,8 @@ class GuideTable(ACACatalogTable):
         """
         Create a candidate list from the available stars in the field.
         """
-        stars = self.meta['stars']
-        dark = self.meta['dark']
+        stars = self.stars
+        dark = self.dark
 
         # Use the primary selection filter from acq, but allow bad color
         # and limit to brighter stars
@@ -261,8 +236,8 @@ class GuideTable(ACACatalogTable):
         stars['offchip'] = offchip
 
         # Add a filter for stars that are too close to the chip edge including dither
-        r_dith_pad = self.meta['dither'].row
-        c_dith_pad = self.meta['dither'].col
+        r_dith_pad = self.dither.row
+        c_dith_pad = self.dither.col
         row_max = CCD['row_max'] - (CCD['row_pad'] + CCD['window_pad'] + r_dith_pad)
         col_max = CCD['col_max'] - (CCD['col_pad'] + CCD['window_pad'] + c_dith_pad)
         outofbounds = (np.abs(stars['row']) > row_max) | (np.abs(stars['col']) > col_max)
@@ -273,7 +248,7 @@ class GuideTable(ACACatalogTable):
         self.log(f'Reduced star list from {len(stars)} to '
                  f'{len(cand_guides)} candidate guide stars')
 
-        bp = spoiled_by_bad_pixel(cand_guides, self.meta['dither'])
+        bp = spoiled_by_bad_pixel(cand_guides, self.dither)
         cand_guides = cand_guides[~bp]
         self.log('Filtering on candidates near bad (not just bright/hot) pixels')
         self.log(f'Reduced star list from {len(bp)} to '
@@ -293,7 +268,7 @@ class GuideTable(ACACatalogTable):
         self.log(f'Reduced star list from {len(box_spoiled)} to '
                  f'{len(cand_guides)} candidate guide stars')
 
-        cand_guides['imp_mag'] = get_imposter_mags(cand_guides, dark, self.meta['dither'])
+        cand_guides['imp_mag'] = get_imposter_mags(cand_guides, dark, self.dither)
         self.log('Getting pseudo-mag of brightest pixel in candidate region')
 
         return cand_guides

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -38,7 +38,7 @@ def get_guide_catalog(obsid=0, **kwargs):
     """
 
     guides = GuideTable()
-    guides.set_kwargs(obsid=obsid, **kwargs)
+    guides.set_attrs_from_kwargs(obsid=obsid, **kwargs)
     guides.set_stars()
 
     if guides.dark is None:

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -11,7 +11,7 @@ from chandra_aca.star_probs import guide_count
 from . import characteristics as CHAR
 from . import characteristics_guide as GUIDE_CHAR
 
-from .core import StarsTable, bin2x2, ACACatalogTable, ACABox, MetaAttribute
+from .core import bin2x2, ACACatalogTable, ACABox, MetaAttribute
 
 CCD = GUIDE_CHAR.CCD
 
@@ -297,9 +297,8 @@ def check_spoil_contrib(cand_stars, ok, stars, regfrac, bgthresh):
     for cand in cand_stars[ok]:
         if cand['ASPQ1'] == 0:
             continue
-        pix_dist = np.sqrt(((cand['row'] - stars['row']) ** 2) + ((cand['col'] - stars['col']) ** 2))
-        spoilers = ((np.abs(cand['row'] - stars['row']) < 9)
-                    & (np.abs(cand['col'] - stars['col']) < 9))
+        spoilers = ((np.abs(cand['row'] - stars['row']) < 9) &
+                    (np.abs(cand['col'] - stars['col']) < 9))
 
         # If there is only one match, it is the candidate so there's nothing to do
         if np.count_nonzero(spoilers) == 1:
@@ -349,7 +348,6 @@ def check_mag_spoilers(cand_stars, ok, stars, n_sigma):
     :param n_sigma: multiplier use for mag_err when reviewing spoilers
     :returns: bool mask of length cand_stars marking mag_spoiled stars
     """
-    maxsep = GUIDE_CHAR.mag_spoiler['MaxSep']
     intercept = GUIDE_CHAR.mag_spoiler['Intercept']
     spoilslope = GUIDE_CHAR.mag_spoiler['Slope']
     magdifflim = GUIDE_CHAR.mag_spoiler['MagDiffLimit']
@@ -361,9 +359,10 @@ def check_mag_spoilers(cand_stars, ok, stars, n_sigma):
     mag_spoiled = np.zeros(len(ok)).astype(bool)
 
     for cand in cand_stars[ok]:
-        pix_dist = np.sqrt(((cand['row'] - stars['row']) **2) + ((cand['col'] - stars['col']) ** 2))
-        spoilers = ((np.abs(cand['row'] - stars['row']) < 10)
-                    & (np.abs(cand['col'] - stars['col']) < 10))
+        pix_dist = np.sqrt(((cand['row'] - stars['row']) ** 2) +
+                           ((cand['col'] - stars['col']) ** 2))
+        spoilers = ((np.abs(cand['row'] - stars['row']) < 10) &
+                    (np.abs(cand['col'] - stars['col']) < 10))
 
         # If there is only one match, it is the candidate so there's nothing to do
         if np.count_nonzero(spoilers) == 1:
@@ -401,12 +400,12 @@ def check_column_spoilers(cand_stars, ok, stars, n_sigma):
             continue
         dcol = cand['col'] - stars['col'][~stars['offchip']]
         direction = stars['row'][~stars['offchip']] / cand['row']
-        pos_spoil = ((np.abs(dcol) <= (GUIDE_CHAR.col_spoiler['Separation']))
-                     & (direction > 1.0))
+        pos_spoil = ((np.abs(dcol) <= (GUIDE_CHAR.col_spoiler['Separation'])) &
+                     (direction > 1.0))
         if not np.count_nonzero(pos_spoil) >= 1:
             continue
-        mag_errs = (n_sigma * np.sqrt(cand['mag_err'] ** 2
-                                      + stars['mag_err'][~stars['offchip']][pos_spoil] ** 2))
+        mag_errs = (n_sigma * np.sqrt(cand['mag_err'] ** 2 +
+                                      stars['mag_err'][~stars['offchip']][pos_spoil] ** 2))
         dm = (cand['mag'] - stars['mag'][~stars['offchip']][pos_spoil] + mag_errs)
         if np.any(dm > GUIDE_CHAR.col_spoiler['MagDiff']):
             column_spoiled[idx] = True

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -18,7 +18,8 @@ from astropy.table import Table, Column
 from chandra_aca.aca_image import ACAImage
 
 from . import characteristics as CHAR
-from .acq import AcqTable, StarsTable
+from .acq import AcqTable
+from .core import StarsTable
 from chandra_aca import plot as plot_aca
 from mica.archive.aca_dark.dark_cal import get_dark_cal_image
 
@@ -192,7 +193,7 @@ def make_acq_star_details_report(acqs, cand_acqs, events, context, obsdir):
     # Candidate acq star detail sections
     ######################################################
     acqs.dark = get_dark_cal_image(date=acqs.date, select='nearest',
-                                           t_ccd_ref=acqs.t_ccd)
+                                   t_ccd_ref=acqs.t_ccd)
 
     context['cand_acqs'] = []
 

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -192,7 +192,7 @@ def make_acq_star_details_report(acqs, cand_acqs, events, context, obsdir):
     ######################################################
     # Candidate acq star detail sections
     ######################################################
-    acqs.dark = get_dark_cal_image(date=acqs.date, select='nearest',
+    acqs.dark = get_dark_cal_image(date=acqs.date, select='before',
                                    t_ccd_ref=acqs.t_ccd)
 
     context['cand_acqs'] = []

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -9,12 +9,12 @@ from chandra_aca.transform import mag_to_count_rate, yagzag_to_pixels
 
 from ..report import make_report
 from ..acq import (get_p_man_err, bin2x2, CHAR,
-                   get_imposter_stars, StarsTable,
+                   get_imposter_stars,
                    get_image_props, calc_p_brightest,
                    AcqTable, calc_p_on_ccd,
                    get_acq_catalog,
                    )
-from ..core import ACABox
+from ..core import ACABox, StarsTable
 from .test_common import OBS_INFO, STD_INFO
 
 TEST_DATE = '2018:144'  # Fixed date for doing tests

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -373,7 +373,7 @@ def test_get_acq_catalog_19387():
     >>> from proseco.acq import AcqTable
     >>> acqs = get_acq_catalog(19387)
     >>> TEST_COLS = ('idx', 'slot', 'id', 'yang', 'zang', 'halfw', 'mag', 'p_acq')
-    >>> repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines()
+    >>> repr(acqs.cand_acqs[TEST_COLS]).splitlines()
     """
     acqs = get_acq_catalog(**OBS_INFO[19387])
     # Expected
@@ -393,7 +393,7 @@ def test_get_acq_catalog_19387():
            '    9  ... 37880152 -1542.43   970.39   120   10.88   0.008',
            '   10  ... 37882776  1485.00   127.97   120   10.93   0.007']
 
-    assert repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines() == exp
+    assert repr(acqs.cand_acqs[TEST_COLS]).splitlines() == exp
 
 
 def test_get_acq_catalog_21007():
@@ -402,7 +402,7 @@ def test_get_acq_catalog_21007():
     >>> from proseco.acq import AcqTable
     >>> acqs = get_acq_catalog(21007)
     >>> TEST_COLS = ('idx', 'slot', 'id', 'yang', 'zang', 'halfw', 'mag', 'p_acq')
-    >>> repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines()
+    >>> repr(acqs.cand_acqs[TEST_COLS]).splitlines()
     """
     acqs = get_acq_catalog(**OBS_INFO[21007])
 
@@ -425,7 +425,7 @@ def test_get_acq_catalog_21007():
            '   12  ... 189017968  1612.35 -1117.76   120   10.98   0.000',
            '   13  ... 189011576   553.50 -2473.81   120   10.99   0.000']
 
-    assert repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines() == exp
+    assert repr(acqs.cand_acqs[TEST_COLS]).splitlines() == exp
 
 
 def test_box_strategy_20603():
@@ -452,7 +452,7 @@ def test_box_strategy_20603():
            '   11  ... 116923744  -853.18   937.73   120   10.84   0.000',
            '   12  ... 116918232 -2074.91 -1769.96   120   10.96   0.000']
 
-    assert repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines() == exp
+    assert repr(acqs.cand_acqs[TEST_COLS]).splitlines() == exp
 
 
 def test_make_report(tmpdir):
@@ -476,13 +476,13 @@ def test_make_report(tmpdir):
     assert len(list(obsdir.glob('*.png'))) > 0
 
     assert repr(acqs) == repr(acqs2)
-    assert repr(acqs.meta['cand_acqs']) == repr(acqs2.meta['cand_acqs'])
+    assert repr(acqs.cand_acqs) == repr(acqs2.cand_acqs)
     for event, event2 in zip(acqs.log_info, acqs2.log_info):
         assert event == event2
 
     for attr in ['att', 'date', 't_ccd', 'man_angle', 'dither', 'p_safe']:
-        val = acqs.meta[attr]
-        val2 = acqs2.meta[attr]
+        val = getattr(acqs, attr)
+        val2 = getattr(acqs2, attr)
         if isinstance(val, float):
             assert np.isclose(val, val2)
         else:
@@ -517,7 +517,7 @@ def test_cand_acqs_include_exclude():
     acqs = get_acq_catalog(**STD_INFO, optimize=False, stars=stars)
     assert np.all(acqs['id'] == np.arange(1, 9))
     assert np.all(acqs['halfw'] == 160)
-    assert np.all(acqs.meta['cand_acqs']['id'] == np.arange(1, 11))
+    assert np.all(acqs.cand_acqs['id'] == np.arange(1, 11))
 
     # Define includes and excludes. id=9 is in nominal cand_acqs but not in acqs.
     include_ids = [9, 11]
@@ -529,10 +529,10 @@ def test_cand_acqs_include_exclude():
                                include_ids=include_ids, include_halfws=include_halfws,
                                exclude_ids=exclude_ids)
 
-        assert acqs.meta['include_ids'] == include_ids
-        assert acqs.meta['include_halfws'] == include_halfws
-        assert acqs.meta['exclude_ids'] == exclude_ids
-        assert all(id_ in acqs.meta['cand_acqs']['id'] for id_ in include_ids)
+        assert acqs.include_ids == include_ids
+        assert acqs.include_halfws == include_halfws
+        assert acqs.exclude_ids == exclude_ids
+        assert all(id_ in acqs.cand_acqs['id'] for id_ in include_ids)
 
         assert all(id_ in acqs['id'] for id_ in include_ids)
         assert all(id_ not in acqs['id'] for id_ in exclude_ids)
@@ -542,15 +542,15 @@ def test_cand_acqs_include_exclude():
         assert np.allclose(acqs['mag'], [7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 10.0, 12.0])
 
     # Re-optimize catalog now after removing include and exclude
-    acqs.meta['exclude_ids'] = []
-    acqs.meta['include_ids'] = []
-    acqs.meta['include_halfws'] = []
+    acqs.exclude_ids = []
+    acqs.include_ids = []
+    acqs.include_halfws = []
 
     # Now starting from the catalog chosen with the include/exclude
     # constraints applied, remove those constraints and re-optimize.
     # This must come back to the original catalog of the 8 bright stars.
     del acqs['slot']
-    del acqs.meta['cand_acqs']['slot']
+    del acqs.cand_acqs['slot']
     acqs.optimize_catalog()
     acqs.sort('idx')
     assert np.all(acqs['id'] == np.arange(1, 9))
@@ -580,7 +580,7 @@ def test_dither_as_sequence():
 
     acqs = get_acq_catalog(**kwargs, stars=stars)
     assert len(acqs) == 8
-    assert acqs.meta['dither'] == (8, 22)
+    assert acqs.dither == (8, 22)
 
 
 def test_n_acq():
@@ -611,7 +611,7 @@ def test_n_acq():
            '   10  ...   106 -1000.00  1000.00   120   10.06   0.797',
            '   11  ...   107 -1000.00 -1000.00   120   10.07   0.787']
 
-    assert repr(acqs.meta['cand_acqs'][TEST_COLS]).splitlines() == exp
+    assert repr(acqs.cand_acqs[TEST_COLS]).splitlines() == exp
 
 
 def test_warnings():

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -395,6 +395,21 @@ def test_get_acq_catalog_19387():
 
     assert repr(acqs.cand_acqs[TEST_COLS]).splitlines() == exp
 
+    exp = ['<AcqTable length=8>',
+           ' idx   slot    id      yang     zang   halfw   mag    p_acq ',
+           'int64 int64  int32   float64  float64  int64 float32 float64',
+           '----- ----- -------- -------- -------- ----- ------- -------',
+           '    0     0 38280776 -2254.09 -2172.43   160    8.77   0.985',
+           '    1     1 37879960  -567.34  -632.27    80    9.20   0.984',
+           '    2     2 37882072  2197.62  1608.89    80   10.16   0.956',
+           '    3     3 37879992   318.47 -1565.92    60   10.41   0.933',
+           '    4     4 37882416   481.80  2204.44    80   10.41   0.901',
+           '    5     5 37880176   121.33 -1068.25    60   10.62   0.584',
+           '    6     6 37881728  2046.89  1910.79   100   10.76   0.057',
+           '    7     7 37880376 -1356.71  1071.32   100   10.80   0.084']
+
+    assert repr(acqs[TEST_COLS]).splitlines() == exp
+
 
 def test_get_acq_catalog_21007():
     """Put it all together.  Regression test for selected stars.
@@ -427,6 +442,21 @@ def test_get_acq_catalog_21007():
 
     assert repr(acqs.cand_acqs[TEST_COLS]).splitlines() == exp
 
+    exp = ['<AcqTable length=8>',
+           ' idx   slot     id      yang     zang   halfw   mag    p_acq ',
+           'int64 int64   int32   float64  float64  int64 float32 float64',
+           '----- ----- --------- -------- -------- ----- ------- -------',
+           '    0     0 189417400 -2271.86 -1634.77   160    7.71   0.985',
+           '    1     1 189410928   -62.52  1763.04   160    8.84   0.982',
+           '    2     2 189409160 -2223.75  1998.69   160    9.84   0.876',
+           '    3     3 189417920  1482.94   243.72   160    9.94   0.807',
+           '    4     4 189015480  2222.47  -580.99    60   10.01   0.538',
+           '    5     5 189417752  1994.07   699.55   100   10.24   0.503',
+           '    6     6 189406216 -2311.90  -240.18    60   10.26   0.742',
+           '    7     7 189416328  1677.88   137.11    60   10.40   0.348']
+
+    assert repr(acqs[TEST_COLS]).splitlines() == exp
+
 
 def test_box_strategy_20603():
     """Test for PR #32 that doesn't allow p_acq to be reduced below 0.1.
@@ -453,6 +483,21 @@ def test_box_strategy_20603():
            '   12  ... 116918232 -2074.91 -1769.96   120   10.96   0.000']
 
     assert repr(acqs.cand_acqs[TEST_COLS]).splitlines() == exp
+
+    exp = ['<AcqTable length=8>',
+           ' idx   slot     id      yang     zang   halfw   mag    p_acq ',
+           'int64 int64   int32   float64  float64  int64 float32 float64',
+           '----- ----- --------- -------- -------- ----- ------- -------',
+           '    0     0  40113544   102.74  1133.37   160    7.91   0.985',
+           '    1     1 116791824   622.00  -953.60   160    9.01   0.958',
+           '    2     2 116923496 -1337.79  1049.27   120    9.14   0.970',
+           '    3     3  40114416   394.22  1204.43   140    9.78   0.912',
+           '    4     4  40112304 -1644.35  2032.47   160    9.79   0.687',
+           '    5     5 116923528 -2418.65  1088.40   160    9.84   0.593',
+           '    6     6 116791744   985.38 -1210.19   140   10.29   0.347',
+           '    8     7 116785920  -673.94 -1575.87    60   10.50   0.136']
+
+    assert repr(acqs[TEST_COLS]).splitlines() == exp
 
 
 def test_make_report(tmpdir):

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -82,7 +82,7 @@ def test_big_dither_from_mica_starcheck():
     observation like 20168.
     """
     aca = ACACatalogTable()
-    aca.set_kwargs(obsid=20168)
+    aca.set_attrs_from_kwargs(obsid=20168)
 
     assert aca.detector == 'HRC-S'
     assert aca.dither_acq == (20, 20)

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import mica.starcheck
 
-from ..core import StarsTable
+from ..core import StarsTable, ACACatalogTable
 from ..catalog import get_aca_catalog
 
 
@@ -73,3 +73,17 @@ def test_no_candidates():
     assert 'halfw' in acas.acqs.colnames
     assert 'id' in acas.guides.colnames
     assert 'id' in acas.fids.colnames
+
+
+@pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
+def test_big_dither_from_mica_starcheck():
+    """
+    Test code that infers dither_acq and dither_guide for a big-dither
+    observation like 20168.
+    """
+    aca = ACACatalogTable()
+    aca.set_kwargs(obsid=20168)
+
+    assert aca.detector == 'HRC-S'
+    assert aca.dither_acq == (20, 20)
+    assert aca.dither_guide == (64, 8)

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -11,7 +11,7 @@ from .. import characteristics_fid as FID
 
 
 # Reference fid positions for spoiling tests
-FIDS = get_fid_catalog(**STD_INFO)
+FIDS = get_fid_catalog(stars=StarsTable.empty(), **STD_INFO)
 
 
 def test_get_fid_position():
@@ -63,8 +63,10 @@ def test_get_initial_catalog():
 
     # Make catalogs with some fake stars (at exactly fid positions) that spoil
     # the fids.
-    stars = FIDS.cand_fids.copy()
-    stars['mag_err'] = 0.1
+    stars = StarsTable.empty()
+    for fid in FIDS.cand_fids:
+        stars.add_fake_star(mag=fid['mag'], mag_err=0.1,
+                            yang=fid['yang'], zang=fid['zang'])
 
     # Spoil fids 1, 2
     fids2 = get_fid_catalog(stars=stars[:2], **STD_INFO)
@@ -167,7 +169,8 @@ def test_dither_as_sequence():
     std_info['dither'] = (8, 22)
     fids = get_fid_catalog(**std_info)
     assert len(fids) == 3
-    assert fids.dither == (8, 22)
+    assert fids.dither_acq == (8, 22)
+    assert fids.dither_guide == (8, 22)
 
 
 def test_fid_spoiler_score():

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -11,7 +11,7 @@ from .. import characteristics_fid as FID
 
 
 # Reference fid positions for spoiling tests
-FIDS = get_fid_catalog(detector='ACIS-S')
+FIDS = get_fid_catalog(**STD_INFO)
 
 
 def test_get_fid_position():
@@ -58,16 +58,16 @@ def test_get_initial_catalog():
            '    4  2140.23   166.63 -424.51   39.13    7.00             0    1',
            '    5 -1826.28   160.17  372.97   36.47    7.00             0    2',
            '    6   388.59   803.75  -71.49  166.10    7.00             0  ...']
-    assert repr(FIDS.meta['cand_fids']).splitlines() == exp
+    assert repr(FIDS.cand_fids).splitlines() == exp
     assert np.all(FIDS['id'] == [2, 4, 5])
 
     # Make catalogs with some fake stars (at exactly fid positions) that spoil
     # the fids.
-    stars = FIDS.meta['cand_fids'].copy()
+    stars = FIDS.cand_fids.copy()
     stars['mag_err'] = 0.1
 
     # Spoil fids 1, 2
-    fids2 = get_fid_catalog(detector='ACIS-S', stars=stars[:2], dither=8)
+    fids2 = get_fid_catalog(stars=stars[:2], **STD_INFO)
     exp = ['<FidTable length=6>',
            '  id    yang     zang     row     col     mag   spoiler_score slot',
            'int64 float64  float64  float64 float64 float64     int64     str3',
@@ -78,16 +78,16 @@ def test_get_initial_catalog():
            '    4  2140.23   166.63 -424.51   39.13    7.00             0    1',
            '    5 -1826.28   160.17  372.97   36.47    7.00             0    2',
            '    6   388.59   803.75  -71.49  166.10    7.00             0  ...']
-    assert repr(fids2.meta['cand_fids']).splitlines() == exp
+    assert repr(fids2.cand_fids).splitlines() == exp
     assert np.all(fids2['id'] == [3, 4, 5])
 
     # Spoil fids 1, 2, 3
-    fids3 = get_fid_catalog(detector='ACIS-S', stars=stars[:3], dither=8)
+    fids3 = get_fid_catalog(stars=stars[:3], **STD_INFO)
     assert np.all(fids3['id'] == [4, 5, 6])
     assert fids3.thumbs_up
 
     # Spoil fids 1, 2, 3, 4 => no initial catalog gets found
-    fids4 = get_fid_catalog(detector='ACIS-S', stars=stars[:4], dither=8)
+    fids4 = get_fid_catalog(stars=stars[:4], **STD_INFO)
     assert len(fids4) == 0
     assert not fids4.thumbs_up
     assert all(name in fids4.colnames for name in ['id', 'yang', 'zang', 'row', 'col'])
@@ -97,7 +97,7 @@ def test_n_fid():
     """Test specifying number of fids.
     """
     # Get only 2 fids
-    fids = get_fid_catalog(detector='ACIS-S', dither=8, n_fid=2)
+    fids = get_fid_catalog(n_fid=2, **STD_INFO)
     assert len(fids) == 2
     assert fids.thumbs_up
 
@@ -127,11 +127,11 @@ def test_fid_spoiling_acq(dither_z):
                             zang=fid['zang'] + offset + dither_z,
                             mag=7.0)
 
-    kwargs = STD_INFO.copy()
-    kwargs['dither'] = (dither_y, dither_z)
-    acqs = get_acq_catalog(stars=stars, **kwargs)
+    std_info = STD_INFO.copy()
+    std_info['dither'] = (dither_y, dither_z)
+    acqs = get_acq_catalog(stars=stars, **std_info)
     acqs['halfw'] = 100
-    fids5 = get_fid_catalog(acqs=acqs)
+    fids5 = get_fid_catalog(acqs=acqs, **std_info)
     exp = ['<FidTable length=6>',
            '  id    yang     zang     row     col     mag   spoiler_score slot',
            'int64 float64  float64  float64 float64 float64     int64     str3',
@@ -143,7 +143,7 @@ def test_fid_spoiling_acq(dither_z):
            '    5 -1826.28   160.17  372.97   36.47    7.00             0    1',
            '    6   388.59   803.75  -71.49  166.10    7.00             0    2']
 
-    assert repr(fids5.meta['cand_fids']).splitlines() == exp
+    assert repr(fids5.cand_fids).splitlines() == exp
 
 
 def test_fid_mult_spoilers():
@@ -151,8 +151,8 @@ def test_fid_mult_spoilers():
     Test of fix for bug #54.  19605 and 20144 were previous crashing.
     """
     acqs = get_acq_catalog(**OBS_INFO[19605])
-    fids = get_fid_catalog(acqs=acqs)
-    cand_fids = fids.meta['cand_fids']
+    fids = get_fid_catalog(acqs=acqs, **OBS_INFO[19605])
+    cand_fids = fids.cand_fids
     assert np.all(cand_fids['spoiler_score'] == [0, 0, 1, 4, 0, 0])
     assert len(cand_fids['spoilers'][2]) == 1
     assert cand_fids['spoilers'][2]['warn'][0] == 'yellow'
@@ -163,9 +163,11 @@ def test_dither_as_sequence():
     Test that calling get_acq_catalog with a 2-element sequence (dither_y, dither_z)
     gives the expected response.  (Basically that it still returns a catalog).
     """
-    fids = get_fid_catalog(detector='ACIS-S', dither=(8, 22))
+    std_info = STD_INFO.copy()
+    std_info['dither'] = (8, 22)
+    fids = get_fid_catalog(**std_info)
     assert len(fids) == 3
-    assert fids.meta['dither'] == (8, 22)
+    assert fids.dither == (8, 22)
 
 
 def test_fid_spoiler_score():
@@ -178,5 +180,8 @@ def test_fid_spoiler_score():
                             mag=7.0)
 
     dither = (dither_y, dither_z)
-    fids = get_fid_catalog(stars=stars, detector='ACIS-S', dither=dither)
-    assert np.all(fids.meta['cand_fids']['spoiler_score'] == [0, 4, 0, 0, 0, 0])
+
+    std_info = STD_INFO.copy()
+    std_info['dither'] = dither
+    fids = get_fid_catalog(stars=stars, **std_info)
+    assert np.all(fids.cand_fids['spoiler_score'] == [0, 4, 0, 0, 0, 0])

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -1,8 +1,6 @@
 import pytest
 import numpy as np
 
-from chandra_aca.transform import yagzag_to_pixels
-
 from ..fid import get_fid_positions, get_fid_catalog
 from ..acq import get_acq_catalog
 from ..core import StarsTable


### PR DESCRIPTION
It all started with the realization that fid selection needs to use `dither_guide` to check for stars that spoil a fid, and `dither_acq` to check if a fid spoils and acq.  Implementing this would have made a somewhat ugly situation even worse.  

So against my better judgement I got pulled down the slippery slope of just making all the fixes to unify the acq, guide, and fid selection parameters via a new `MetaAttribute` descriptor, and an hour or two dragged into a very long morning to get everything working again.  Overall I think the code is a lot cleaner now, especially in `catalog.py` which was mostly deletions.