### PR TITLE
Implement fid-set dependent acq probability machinery 

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -1093,14 +1093,14 @@ class AcqProbs:
 
             p_fid_id_spoiler = 1.0
             try:
-                fid = fids.meta['cand_fids'].get_id(fid_id)
+                fid = fids.cand_fids.get_id(fid_id)
             except (KeyError, IndexError, AssertionError):
                 # This should not happen, but ignore with a warning in any case.  Non-candidate
                 # fid cannot spoil an acq star.
                 self.acqs.add_warning(f'Requested fid spoiler probability for fid '
                                       f'{self.acqs.detector}-{fid_id} but it is not a candidate')
             else:
-                if fids.spoils(fid, self.acq['yang'], self.acq['zang'], box_size):
+                if fids.spoils(fid, self.acq, box_size):
                     p_fid_id_spoiler = 0.0
 
             self._p_fid_id_spoiler[box_size, fid_id] = p_fid_id_spoiler

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -529,7 +529,7 @@ class AcqTable(ACACatalogTable):
             acqs = self[ok]
 
             # Sort by the marginalized acq probability for the current box size
-            p_acqs = [acq['probs'].p_acq_marg[acq['halfw']] for acq in acqs]
+            p_acqs = [acq['probs'].p_acq_marg(acq['halfw']) for acq in acqs]
             idx_worst = np.argsort(p_acqs)[0]
 
             idx = self.get_id_idx(acqs[idx_worst]['id'])
@@ -1097,7 +1097,6 @@ class AcqProbs:
             self._p_fid_id_spoiler[box_size, fid_id] = p_fid_id_spoiler
 
             return p_fid_id_spoiler
->>>>>>> First steps including fid spoilers to acq probs
 
 
 def get_p_man_err(man_err, man_angle):

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -80,7 +80,7 @@ def get_acq_catalog(obsid=0, **kwargs):
         acqs.optimize_catalog(acqs.verbose)
 
     # Set p_acq column to be the marginalized probabilities
-    acqs['p_acq'] = [acq['probs'].p_acq_marg[acq['halfw']] for acq in acqs]
+    acqs['p_acq'] = [acq['probs'].p_acq_marg(acq['halfw']) for acq in acqs]
 
     # Sort to make order match the original candidate list order (by
     # increasing mag), and assign a slot.
@@ -299,7 +299,7 @@ class AcqTable(ACACatalogTable):
         for box_size in CHAR.box_sizes:
             # Get array of marginalized (over man_err) p_acq values corresponding
             # to box_size for each of the candidate acq stars.
-            p_acqs_for_box = np.array([acq['probs'].p_acq_marg[box_size] for acq in cand_acqs])
+            p_acqs_for_box = np.array([acq['probs'].p_acq_marg(box_size) for acq in cand_acqs])
 
             self.log(f'Trying search box size {box_size} arcsec', level=1)
 
@@ -368,7 +368,7 @@ class AcqTable(ACACatalogTable):
         cand_acqs['halfw'] = 120
         cand_acqs['halfw'][acq_indices] = box_sizes
         for acq in cand_acqs:
-            acq['p_acq'] = acq['probs'].p_acq_marg[acq['halfw']]
+            acq['p_acq'] = acq['probs'].p_acq_marg(acq['halfw'])
 
         # Finally select the initial catalog
         acqs_init = cand_acqs[acq_indices]
@@ -391,7 +391,7 @@ class AcqTable(ACACatalogTable):
             if p_man_err == 0.0:
                 continue
 
-            p_acqs = [acq['probs'].p_acqs[acq['halfw'], man_err] for acq in self]
+            p_acqs = [acq['probs'].p_acqs(acq['halfw'], man_err) for acq in self]
 
             p_n_cum = prob_n_acq(p_acqs)[1]
             if verbose:
@@ -419,14 +419,14 @@ class AcqTable(ACACatalogTable):
         """
         acq = self[idx]
         orig_halfw = acq['halfw']
-        orig_p_acq = acq['probs'].p_acq_marg[acq['halfw']]
+        orig_p_acq = acq['probs'].p_acq_marg(acq['halfw'])
 
         self.log(f'Optimizing halfw for idx={idx} id={acq["id"]}', id=acq['id'])
 
         # Compute p_safe for each possible halfw for the current star
         p_safes = []
         for box_size in CHAR.box_sizes:
-            new_p_acq = acq['probs'].p_acq_marg[box_size]
+            new_p_acq = acq['probs'].p_acq_marg(box_size)
             # Do not reduce marginalized p_acq to below 0.1.  It can happen that p_safe
             # goes down very slightly with an increase in box size from the original,
             # and then the box size gets stuck there because of the deadband for later
@@ -962,11 +962,18 @@ class AcqProbs:
         :param date: observation date
         :param man_angle: maneuver angle (float, deg)
         """
-        self.p_brightest = {}
-        self.p_acq_model = {}
-        self.p_on_ccd = {}
-        self.p_acqs = {}
-        self.p_acq_marg = {}
+        self._p_brightest = {}
+        self._p_acq_model = {}
+        self._p_on_ccd = {}
+        self._p_acqs = {}
+        self._p_acq_marg = {}
+        self._p_fid_spoiler = {}
+        self._p_fid_id_spoiler = {}
+
+        self.acqs = acqs
+
+        # Convert table row to plain dict for persistence
+        self.acq = {key: acq[key] for key in ('yang', 'zang')}
 
         for box_size in CHAR.box_sizes:
             # Need to iterate over man_errs in reverse order because calc_p_brightest
@@ -974,7 +981,7 @@ class AcqProbs:
             # box sizes.
             for man_err in CHAR.man_errs[::-1]:
                 if man_err > box_size:
-                    p_brightest = self.p_brightest[box_size, man_err] = 0.0
+                    p_brightest = self._p_brightest[box_size, man_err] = 0.0
                 else:
                     # Prob of being brightest in box (function of box_size and
                     # man_err, independently because imposter prob is just a
@@ -982,29 +989,115 @@ class AcqProbs:
                     # function of dither, but that does not vary here.
                     p_brightest = calc_p_brightest(acq, box_size=box_size, stars=stars,
                                                    dark=dark, man_err=man_err, dither=dither)
-                    self.p_brightest[box_size, man_err] = p_brightest
+                    self._p_brightest[box_size, man_err] = p_brightest
 
         # Acquisition probability model value (function of box_size only)
         for box_size in CHAR.box_sizes:
             p_acq_model = acq_success_prob(date=date, t_ccd=t_ccd,
                                            mag=acq['mag'], color=acq['color'],
                                            spoiler=False, halfwidth=box_size)
-            self.p_acq_model[box_size] = p_acq_model
+            self._p_acq_model[box_size] = p_acq_model
 
         # Probability star is in acq box (function of man_err and dither only)
         for man_err in CHAR.man_errs:
             p_on_ccd = calc_p_on_ccd(acq['row'], acq['col'], box_size=man_err + dither)
-            self.p_on_ccd[man_err] = p_on_ccd
+            self._p_on_ccd[man_err] = p_on_ccd
 
-        # All together now!
-        for box_size in CHAR.box_sizes:
+    @property
+    def fid_set(self):
+        fids = self.acqs.fids
+        return () if (fids is None) else fids.fid_set
+
+    def p_on_ccd(self, man_err):
+        return self._p_on_ccd[man_err]
+
+    def p_brightest(self, box_size, man_err):
+        return self._p_brightest[box_size, man_err]
+
+    def p_acq_model(self, box_size):
+        return self._p_acq_model[box_size]
+
+    def p_acqs(self, box_size, man_err):
+        try:
+            return self._p_acqs[box_size, man_err, self.fid_set]
+        except KeyError:
+            p_acq = (self.p_brightest(box_size, man_err) *
+                     self.p_acq_model(box_size) *
+                     self.p_on_ccd(man_err) *
+                     self.p_fid_spoiler(box_size))
+            self._p_acqs[box_size, man_err, self.fid_set] = p_acq
+            return p_acq
+
+    def p_acq_marg(self, box_size):
+        try:
+            return self._p_acq_marg[box_size, self.fid_set]
+        except KeyError:
             p_acq_marg = 0.0
-            for man_err, p_man_err in zip(CHAR.man_errs, acqs.p_man_errs):
-                self.p_acqs[box_size, man_err] = (self.p_brightest[box_size, man_err] *
-                                                  self.p_acq_model[box_size] *
-                                                  self.p_on_ccd[man_err])
-                p_acq_marg += self.p_acqs[box_size, man_err] * p_man_err
-            self.p_acq_marg[box_size] = p_acq_marg
+            for man_err, p_man_err in zip(CHAR.man_errs, self.acqs.p_man_errs):
+                p_acq_marg += self.p_acqs(box_size, man_err) * p_man_err
+            self._p_acq_marg[box_size, self.fid_set] = p_acq_marg
+            return p_acq_marg
+
+    def p_fid_spoiler(self, box_size):
+        """
+        Return the probability multiplier based on any fid in the current fid set spoiling
+        this acq star (within ``box_size``).  The current fid set is a property of the
+        ``fids`` table.  The output value will be 1.0 for no spoilers and 0.0 for one or
+        more spoiler (normally there can be at most one fid spoiler).
+
+        This caches the values in a dict for subsequent access.
+
+        :param box_size: search box size in arcsec
+        :returns: probability multiplier (0 or 1)
+        """
+        fid_set = self.fid_set
+        try:
+            return self._p_fid_spoiler[box_size, fid_set]
+        except KeyError:
+            p_fid_spoiler = 1.0
+
+            # If there are fids then multiplier the individual fid spoiler probs
+            for fid_id in fid_set:
+                p_fid_spoiler *= self.p_fid_id_spoiler(box_size, fid_id)
+            self._p_fid_spoiler[box_size, fid_set] = p_fid_spoiler
+
+            return p_fid_spoiler
+
+    def p_fid_id_spoiler(self, box_size, fid_id):
+        """
+        Return the probability multiplier for fid ``fid_id`` spoiling this acq star (within
+        ``box_size``).  The output value will be 0.0 if this fid spoils this acq, otherwise
+        set to 1.0 (no impact).
+
+        This caches the values in a dict for subsequent access.
+
+        :param box_size: search box size in arcsec
+        :returns: probability multiplier (0 or 1)
+        """
+        try:
+            return self._p_fid_id_spoiler[box_size, fid_id]
+        except KeyError:
+            fids = self.acqs.fids
+            if fids is None:
+                warnings.warn('Requested fid spoiler probability without setting acqs.fids first')
+                return 1.0
+
+            p_fid_id_spoiler = 1.0
+            try:
+                fid = fids.meta['cand_fids'].get_id(fid_id)
+            except (KeyError, IndexError, AssertionError):
+                # This should not happen, but ignore with a warning in any case.  Non-candidate
+                # fid cannot spoil an acq star.
+                warnings.warn(f'Requested fid spoiler probability for fid '
+                              f'{self.acqs.meta["detector"]}-{fid_id} but it is not a candidate')
+            else:
+                if fids.spoils(fid, self.acq['yang'], self.acq['zang'], box_size):
+                    p_fid_id_spoiler = 0.0
+
+            self._p_fid_id_spoiler[box_size, fid_id] = p_fid_id_spoiler
+
+            return p_fid_id_spoiler
+>>>>>>> First steps including fid spoilers to acq probs
 
 
 def get_p_man_err(man_err, man_angle):

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -95,12 +95,7 @@ def get_acq_catalog(obsid=0, **kwargs):
         acqs.log(f'Selected only {len(acqs)} acq stars versus requested {acqs.n_acq}',
                  warning=True)
 
-    # Evaluate catalog for thumbs_up status
-    n_acq_probs, n_or_fewer_probs = prob_n_acq(acqs['p_acq'])
-    if len(n_or_fewer_probs) >= 3:
-        acqs.thumbs_up = n_or_fewer_probs[CHAR.acq_prob_n] <= CHAR.acq_prob
-    else:
-        acqs.thumbs_up = False
+    acqs.thumbs_up = acqs.get_p_2_or_fewer() <= CHAR.acq_prob
 
     return acqs
 
@@ -155,6 +150,20 @@ class AcqTable(ACACatalogTable):
     @dither.setter
     def dither(self, value):
         self.dither_acq = value
+
+    def get_p_2_or_fewer(self):
+        """
+        Return the starcheck acquisition merit function of the probability of
+        acquiring two or fewer stars.
+
+        :returns: probability (float)
+        """
+        n_or_fewer_probs = prob_n_acq(self['p_acq'])[1]
+        if len(n_or_fewer_probs) > 2:
+            p_2_or_fewer = n_or_fewer_probs[2]
+        else:
+            p_2_or_fewer = 1.0
+        return p_2_or_fewer
 
     def get_obs_info(self):
         """

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -84,6 +84,8 @@ def _get_aca_catalog(**kwargs):
     aca.acqs = get_acq_catalog(**kwargs)
     aca.fids = get_fid_catalog(acqs=aca.acqs, **kwargs)
 
+    aca.acqs.fids = aca.fids
+
     if len(aca.fids) == 0:
         optimize_acqs_fids(aca.acqs, aca.fids)
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -15,6 +15,10 @@ import agasc
 from Quaternion import Quat
 
 
+# For testing this is used to cache fid tables for a detector
+FIDS_CACHE = {}
+
+
 def yagzag_to_radec(yag, zag, att):
     """
     Convert yag, zag [arcsec] to ra, dec [deg] for attitude ``att``.
@@ -927,6 +931,25 @@ class StarsTable(ACACatalogTable):
         out['MAG_ACA'] = out['mag']
 
         self.add_row(out)
+
+    def add_fake_star_from_fid(self, fid_id, offset_y=0, offset_z=0, mag=7.0,
+                               detector='ACIS-S'):
+        try:
+            fids = FIDS_CACHE[detector]
+        except KeyError:
+            from .fid import get_fid_catalog
+            fids = get_fid_catalog(att=(0, 0, 0),
+                                   detector=detector,
+                                   sim_offset=0,
+                                   focus_offset=0,
+                                   t_ccd=-10.0,
+                                   date='2018:001',
+                                   dither=8.0)
+            FIDS_CACHE[detector] = fids
+
+        fid = fids.cand_fids.get_id(fid_id)
+        self.add_fake_star(yang=fid['yang'] + offset_y, zang=fid['zang'] + offset_z,
+                           mag=mag)
 
 
 def bin2x2(arr):

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -932,8 +932,8 @@ class StarsTable(ACACatalogTable):
 
         self.add_row(out)
 
-    def add_fake_star_from_fid(self, fid_id, offset_y=0, offset_z=0, mag=7.0,
-                               detector='ACIS-S'):
+    def add_fake_stars_from_fid(self, fid_id=1, offset_y=0, offset_z=0, mag=7.0,
+                                id=None, detector='ACIS-S'):
         try:
             fids = FIDS_CACHE[detector]
         except KeyError:
@@ -947,9 +947,16 @@ class StarsTable(ACACatalogTable):
                                    dither=8.0)
             FIDS_CACHE[detector] = fids
 
-        fid = fids.cand_fids.get_id(fid_id)
-        self.add_fake_star(yang=fid['yang'] + offset_y, zang=fid['zang'] + offset_z,
-                           mag=mag)
+        arrays = np.broadcast_arrays(fid_id, offset_y, offset_z, mag, id)
+
+        for fid_id, offset_y, offset_z, mag, id in zip(*arrays):
+            fid = fids.cand_fids.get_id(fid_id)
+            kwargs = dict(yang=fid['yang'] + offset_y,
+                          zang=fid['zang'] + offset_z,
+                          mag=mag)
+            if id is not None:
+                kwargs['id'] = id
+            self.add_fake_star(**kwargs)
 
 
 def bin2x2(arr):

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -86,6 +86,27 @@ class FidTable(ACACatalogTable):
                       'dither_acq', 'dither_guide')
 
     @property
+    def fid_set(self):
+        return self._fid_set
+
+    @fid_set.setter
+    def fid_set(self, fid_ids):
+        if fid_ids is None:
+            self._fid_set = None
+
+        if 'cand_fids' not in self.meta:
+            raise ValueError('cannot set fid_set before selecting candidate fids')
+
+        self._fid_set = ()
+        cand_fids_ids = list(self.meta['cand_fids']['id'])
+        for fid_id in sorted(fid_ids):
+            if fid_id in cand_fids_ids:
+                self._fid_set += (fid_id,)
+            else:
+                warnings.warn(f'fid {fid_id} is not in available candidate '
+                              'fid ids {cand_fids_ids}, ignoring')
+
+    @property
     def acqs(self):
         return self._acqs() if hasattr(self, '_acqs') else None
 
@@ -175,6 +196,8 @@ class FidTable(ACACatalogTable):
         idxs = [cand_fids.get_id_idx(fid_id) for fid_id in sorted(fid_set)]
         for name, col in cand_fids.columns.items():
             self[name] = col[idxs]
+
+        self.fid_set = fid_set
 
     def spoils(self, fid, acq):
         """

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -88,28 +88,6 @@ class FidTable(ACACatalogTable):
                       'dither_acq', 'dither_guide')
 
     @property
-    def fid_set(self):
-        return self._fid_set
-
-    @fid_set.setter
-    def fid_set(self, fid_ids):
-        if fid_ids is None:
-            self._fid_set = None
-
-        if self.cand_fids is None:
-            raise ValueError('cannot set fid_set before selecting candidate fids')
-
-        self._fid_set = ()
-        cand_fids_ids = list(self.cand_fids['id'])
-        for fid_id in sorted(fid_ids):
-            if fid_id in cand_fids_ids:
-                self._fid_set += (fid_id,)
-            else:
-                self.log(f'Fid {fid_id} is not in available candidate '
-                         f'fid ids {cand_fids_ids}, ignoring',
-                         warning=True)
-
-    @property
     def acqs(self):
         return self._acqs() if hasattr(self, '_acqs') else None
 
@@ -201,7 +179,6 @@ class FidTable(ACACatalogTable):
             self[name] = col[idxs]
 
         self.cand_fids = cand_fids
-        self.fid_set = fid_set
 
     def spoils(self, fid, acq, box_size):
         """

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -55,12 +55,12 @@ def get_p_acqs_table(acq, p_name):
     """
     man_errs = CHAR.p_man_errs['man_err_hi']
     box_sizes = sorted(CHAR.box_sizes)
-    names = ['box \ man_err'] + [f'{man_err}"' for man_err in man_errs]
+    names = [r'box \ man_err'] + [f'{man_err}"' for man_err in man_errs]
     cols = {}
-    cols['box \ man_err'] = [f'{box_size}"' for box_size in box_sizes]
+    cols[r'box \ man_err'] = [f'{box_size}"' for box_size in box_sizes]
     for man_err in man_errs:
         name = f'{man_err}"'
-        cols[name] = [round(getattr(acq['probs'], p_name).get((box_size, man_err), 0.0), 3)
+        cols[name] = [round(getattr(acq['probs'], p_name)(box_size, man_err), 3)
                       for box_size in box_sizes]
 
     return table_to_html(Table(cols, names=names))
@@ -79,7 +79,7 @@ def get_p_on_ccd_table(acq):
     cols['man_err'] = ['']
     for man_err in man_errs:
         name = f'{man_err}"'
-        cols[name] = [round(acq['probs'].p_on_ccd[man_err], 3)]
+        cols[name] = [round(acq['probs'].p_on_ccd(man_err), 3)]
 
     return table_to_html(Table(cols, names=names))
 
@@ -97,7 +97,7 @@ def get_p_acq_model_table(acq):
     cols['box size'] = ['']
     for box_size in box_sizes:
         name = f'{box_size}"'
-        cols[name] = [round(acq['probs'].p_acq_model[box_size], 3)]
+        cols[name] = [round(acq['probs'].p_acq_model(box_size), 3)]
 
     return table_to_html(Table(cols, names=names))
 

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pathlib import Path
 
-from chandra_aca.aca_image import AcaPsfLibrary
+from chandra_aca.aca_image import AcaPsfLibrary, ACAImage
 from chandra_aca.transform import mag_to_count_rate, yagzag_to_pixels
 
 from ..report import make_report
@@ -14,8 +14,11 @@ from ..acq import (get_p_man_err, bin2x2, CHAR,
                    AcqTable, calc_p_on_ccd,
                    get_acq_catalog,
                    )
+from ..catalog import get_aca_catalog
 from ..core import ACABox, StarsTable
-from .test_common import OBS_INFO, STD_INFO
+from .test_common import OBS_INFO, STD_INFO, mod_std_info
+from .. import characteristics_fid as FID
+
 
 TEST_DATE = '2018:144'  # Fixed date for doing tests
 ATT = [10, 20, 3]  # Arbitrary test attitude
@@ -682,3 +685,69 @@ def test_no_candidates():
     assert len(acqs) == 0
     assert 'id' in acqs.colnames
     assert 'halfw' in acqs.colnames
+
+
+def test_acq_fid_probs():
+    """
+    Low-level tests of machinery to handle different fid light sets within
+    acquisition probabilities.
+    """
+    dark = ACAImage(np.full(shape=(1024, 1024), fill_value=40), row0=-512, col0=-512)
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(mag=[9.5, 9.6, 9.7], n_stars=3)
+    stars.add_fake_stars_from_fid(fid_id=[1, 2, 3, 4],
+                                  id=[1, 2, 3, 4],
+                                  mag=[10, 8.2, 11.5, 11.5],
+                                  offset_y=[100, 120, 10, 10], detector='HRC-S')
+
+    dither = 20
+    kwargs = mod_std_info(stars=stars, dark=dark, dither=dither,
+                          n_guide=0, n_acq=5, detector='HRC-S')
+    aca = get_aca_catalog(**kwargs)
+
+    acqs = aca.acqs
+
+    print(np.log10(acqs.calc_p_safe()))
+    assert np.allclose(np.log10(acqs.calc_p_safe()), -4.0,
+                       rtol=0, atol=0.05)
+
+    # Initial fid set is empty ()
+    assert acqs.fid_set == ()
+
+    acq = acqs.get_id(2)
+    p0 = acq['probs']
+
+    # FID.spoiler_margin + self.dither_acq + box_size = 50 + 20 + box_size
+    # compared to 120" offset => threshold at 120 - 70 = 50
+    box_size_thresh = 120 - (FID.spoiler_margin + dither)
+    assert p0.p_fid_id_spoiler(box_size_thresh - 1, fid_id=2) == 1.0  # OK
+    assert p0.p_fid_id_spoiler(box_size_thresh + 1, fid_id=2) == 0.0  # spoiled
+
+    # Caching of values
+    assert p0._p_fid_id_spoiler == {(box_size_thresh - 1, 2): 1.0,
+                                    (box_size_thresh + 1, 2): 0.0}
+
+    # With fid_set = (), the probability multiplier for any fid in the fid set
+    # spoiling this star is 1.0, i.e. no fids spoil this star (since there
+    # are no fids).
+    assert p0.p_fid_spoiler(box_size_thresh - 1) == 1.0
+    assert p0.p_fid_spoiler(box_size_thresh + 1) == 1.0
+
+    # Now change the fid set to include ones (in particular fid_id=2) that
+    # spoils an acq star.  This makes the p_safe value much worse.
+    acqs.fid_set = (4, 1, 2)
+    assert acqs.fid_set == (1, 2, 4)  # gets sorted when set
+    print(np.log10(acqs.calc_p_safe()))
+    assert np.allclose(np.log10(acqs.calc_p_safe()), -1.7,
+                       rtol=0, atol=0.05)
+
+    # With fid_set = (1, 2, 4), the probability multiplier for catalog
+    # ids 2 and 4 are spoiled.  This test checks for star id=2 (which is
+    # near fid_id=2).
+    assert p0.p_fid_spoiler(box_size_thresh - 1) == 1.0
+    assert p0.p_fid_spoiler(box_size_thresh + 1) == 0.0
+
+    # Reverting fid set also revert the p_safe value.
+    acqs.fid_set = ()
+    assert np.allclose(np.log10(acqs.calc_p_safe()), -4.0,
+                       rtol=0, atol=0.05)

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -107,7 +107,7 @@ def test_big_dither_from_mica_starcheck():
 def test_pickle():
     stars = StarsTable.empty()
     stars.add_fake_constellation(mag=10.0, n_stars=5)
-    aca = get_aca_catalog(stars=stars, n_guide=5, raise_exc=True, **STD_INFO)
+    aca = get_aca_catalog(stars=stars, raise_exc=True, **STD_INFO)
 
     assert aca.thumbs_up == 0
     assert aca.acqs.thumbs_up == 0

--- a/proseco/tests/test_common.py
+++ b/proseco/tests/test_common.py
@@ -5,6 +5,7 @@ STD_INFO = dict(obsid=1,
                 sim_offset=0,
                 focus_offset=0,
                 date='2018:001',
+                n_guide=5,
                 t_ccd=-11,
                 man_angle=90,
                 dither=8.0)

--- a/proseco/tests/test_common.py
+++ b/proseco/tests/test_common.py
@@ -10,6 +10,12 @@ STD_INFO = dict(obsid=1,
                 man_angle=90,
                 dither=8.0)
 
+
+def mod_std_info(**kwargs):
+    std_info = STD_INFO.copy()
+    std_info.update(kwargs)
+    return std_info
+
 # Parameters for test cases (to avoid starcheck.db3 dependence)
 OBS_INFO = {}
 


### PR DESCRIPTION
~~Optimize fid and acquisition catalogs concurrently.~~

This is now an intermediate step toward concurrent fid and acq catalog testing, with a solid implementation of the fid-set dependent acq probability machinery in place, with testing.

Partially addresses #43.