### PR TITLE
Add plot method and some API consistency

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -138,9 +138,8 @@ class AcqTable(ACACatalogTable):
 
         :returns: StarsTable of stars (empty)
         """
-        out = cls()
-        out['id'] = []
-        out['halfw'] = []
+        out = super().empty()
+        out['halfw'] = np.full(fill_value=0, shape=(0,), dtype=np.int64)
         return out
 
     @property

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -78,9 +78,7 @@ def _get_aca_catalog(**kwargs):
     raise_exc = kwargs.pop('raise_exc')
 
     aca = ACACatalogTable()
-
-    # Put at least the obsid in top level meta for now
-    aca.obsid = kwargs.get('obsid')
+    aca.set_attrs_from_kwargs(**kwargs)
 
     aca.acqs = get_acq_catalog(**kwargs)
     aca.fids = get_fid_catalog(acqs=aca.acqs, **kwargs)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -274,6 +274,23 @@ class ACACatalogTable(Table):
         else:
             self.stars = acqs.stars
 
+    def plot(self, ax=None):
+        """
+        Plot the catalog and background stars.
+
+        :param ax: matplotlib axes object for plotting to (optional)
+        """
+        from chandra_aca.plot import plot_stars
+        import matplotlib.pyplot as plt
+
+        stars_kwargs = {}
+        if self.acqs:
+            stars_kwargs['stars'] = self.acqs.stars
+            stars_kwargs['bad_stars'] = self.acqs.bad_stars
+
+        plot_stars(attitude=self.att, catalog=self, ax=ax, **stars_kwargs)
+        plt.show()
+
     @property
     def dither(self):
         return None

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -322,7 +322,8 @@ class ACACatalogTable(Table):
         :returns: StarsTable of stars (empty)
         """
         out = cls()
-        out['id'] = []
+        out['id'] = np.full(fill_value=0, shape=(0,), dtype=np.int64)
+        out['idx'] = np.full(fill_value=0, shape=(0,), dtype=np.int64)
         return out
 
     def make_index(self):

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -62,6 +62,8 @@ def get_fid_catalog(obsid=0, **kwargs):
     if len(fids) > fids.n_fid:
         fids = fids[:fids.n_fid]
 
+    fids['idx'] = np.arange(len(fids))
+
     # Set fid thumbs_up if fids has the number of requested fid lights
     fids.thumbs_up = len(fids) == fids.n_fid
 

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -59,6 +59,8 @@ def get_guide_catalog(obsid=0, **kwargs):
     for name, col in selected.columns.items():
         guides[name] = col
 
+    guides['idx'] = np.arange(len(guides))
+
     if len(guides) < guides.n_guide:
         guides.log(f'Selected only {len(guides)} guide stars versus requested {guides.n_guide}',
                    warning=True)

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -48,6 +48,18 @@ def test_exception_handling():
                           include_ids=[1])  # Fail
     assert 'ValueError: cannot include star id=1' in aca.exception
 
+    for obj in (aca, aca.acqs, aca.guides, aca.fids):
+        assert len(obj) == 0
+        assert 'id' in obj.colnames
+        assert 'idx' in obj.colnames
+        if obj.name == 'acqs':
+            assert 'halfw' in obj.colnames
+
+
+def test_unhandled_exception():
+    with pytest.raises(TypeError):
+        get_aca_catalog(obsid=None, raise_exc=True)
+
 
 def test_no_candidates():
     """

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -135,6 +135,7 @@ def test_get_kwargs_from_starcheck_text():
            't_ccd': -10.6,
            'date': '2018:273:05:06:58.506',
            'n_guide': 4,
+           'n_fid': 3,
            'detector': 'ACIS-S',
            'sim_offset': 0,
            'focus_offset': 0}


### PR DESCRIPTION
This adds a `plot()` method to allow handy plotting of a merged catalog or acq, guide or fid table catalog.  To get there I needed to do a little tidying so all types have an `idx` column, and also noticed that the `empty()` outputs were float not int (not that it matters to Matlab).

This was a little hack that I mostly did waiting for the sim to ramp up...