### PR TITLE
Update use of magerr in guide star selection

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -390,7 +390,7 @@ def check_column_spoilers(cand_stars, ok, stars, n_sigma):
     :param cand_stars: Table of candidate stars
     :param ok: mask on cand_stars describing still "ok" candidates
     :param stars: Table of AGASC stars
-    :param n_sigma: multiplier used when checking mag with mag_err
+    :param n_sigma: multiplier used when checking mag with MAG_ACA_ERR
     :returns: bool mask on cand_stars marking column spoiled stars
     """
     column_spoiled = np.zeros_like(ok)
@@ -403,8 +403,8 @@ def check_column_spoilers(cand_stars, ok, stars, n_sigma):
                      (direction > 1.0))
         if not np.count_nonzero(pos_spoil) >= 1:
             continue
-        mag_errs = (n_sigma * np.sqrt(cand['mag_err'] ** 2 +
-                                      stars['mag_err'][~stars['offchip']][pos_spoil] ** 2))
+        mag_errs = (n_sigma * np.sqrt(cand['MAG_ACA_ERR'] ** 2 +
+                                      stars['MAG_ACA_ERR'][~stars['offchip']][pos_spoil] ** 2))
         dm = (cand['mag'] - stars['mag'][~stars['offchip']][pos_spoil] + mag_errs)
         if np.any(dm > GUIDE_CHAR.col_spoiler['MagDiff']):
             column_spoiled[idx] = True

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -336,16 +336,15 @@ def check_mag_spoilers(cand_stars, ok, stars, n_sigma):
     """
     Use the slope-intercept mag-spoiler relationship to exclude all
     stars that have a "mag spoiler".  This is basically equivalent to the
-    "direct catalog search" for spoilers in SAUSAGE, but uses the mag_err
-    from the proseco acq, and does not forbid all stars within 7 pixels
-    (spoilers must be faint to be close).
+    "direct catalog search" for spoilers in SAUSAGE, but does not forbid
+    all stars within 7 pixels (spoilers must be faint to be close).
 
     The n-sigma changes by stage for the mags/magerrs used in the check.
 
     :param cand_stars: Table of candidate stars
     :param ok: mask on cand_stars describing those that are still "ok"
     :param stars: Table of AGASC stars in this field
-    :param n_sigma: multiplier use for mag_err when reviewing spoilers
+    :param n_sigma: multiplier use for MAG_ACA_ERR when reviewing spoilers
     :returns: bool mask of length cand_stars marking mag_spoiled stars
     """
     intercept = GUIDE_CHAR.mag_spoiler['Intercept']
@@ -373,7 +372,7 @@ def check_mag_spoilers(cand_stars, ok, stars, n_sigma):
                 continue
             if (cand['mag'] - spoil['mag']) < magdifflim:
                 continue
-            mag_err_sum = np.sqrt(cand['mag_err'] ** 2 + spoil['mag_err'] ** 2)
+            mag_err_sum = np.sqrt(cand['MAG_ACA_ERR'] ** 2 + spoil['MAG_ACA_ERR'] ** 2)
             delmag = cand['mag'] - spoil['mag'] + n_sigma * mag_err_sum
             thsep = intercept + delmag * spoilslope
             if dist < thsep:

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -25,7 +25,7 @@ def test_select():
     """
     selected = get_guide_catalog(att=(10, 20, 3), date='2018:001', dither=(8, 8),
                                  t_ccd=-13, n_guide=5)
-    expected_star_ids = [156384720, 155980240, 156376184, 156381600, 156379416]
+    expected_star_ids = [156384720, 155980240, 156377856, 156376184, 156381600]
     assert selected['id'].tolist() == expected_star_ids
 
 
@@ -207,7 +207,7 @@ def test_check_mag_spoilers():
     """
     intercept = mag_spoiler['Intercept']
     spoilslope = mag_spoiler['Slope']
-    star1 = {'row': 0, 'col': 0, 'mag': 9.0, 'mag_err': 0, 'id': 1}
+    star1 = {'row': 0, 'col': 0, 'mag': 9.0, 'MAG_ACA_ERR': 0, 'id': 1}
 
     # The mag spoiler check only works on stars that are within 10 pixels in row
     # or column, so don't bother simulating stars outside that distance
@@ -217,7 +217,7 @@ def test_check_mag_spoilers():
 
     for r_dist, c_dist, magdiff in itertools.product(r_dists, c_dists, magdiffs):
         star2 = {'row': r_dist, 'col': c_dist, 'mag': star1['mag'] - magdiff,
-                 'mag_err': 0, 'id': 2}
+                 'MAG_ACA_ERR': 0, 'id': 2}
         dist = np.sqrt(r_dist ** 2 + c_dist ** 2)
         stars = Table([star1, star2])
         spoiled = check_mag_spoilers(stars, np.array([True, True]), stars, 0)


### PR DESCRIPTION
Update use of magerr in guide star selection

Specifically, this removes magerr in two use cases and puts back MAG_ACA_ERR in those cases.

Low priority, but this was just how I thought we should go in #67  .