### PR TITLE
Add AcqTable.dark meta attribute

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -57,7 +57,10 @@ def get_acq_catalog(obsid=0, **kwargs):
     acqs.set_stars()
 
     acqs.log(f'getting dark cal image at date={acqs.date} t_ccd={acqs.t_ccd:.1f}')
-    acqs.dark = get_dark_cal_image(date=acqs.date, select='before', t_ccd_ref=acqs.t_ccd)
+
+    # If dark map not provided via input kwarg then get from dark cal archive
+    if acqs.dark is None:
+        acqs.dark = get_dark_cal_image(date=acqs.date, select='before', t_ccd_ref=acqs.t_ccd)
 
     # Probability of man_err for this observation with a given man_angle.  Used
     # for marginalizing probabilities over different man_errs.
@@ -114,6 +117,7 @@ class AcqTable(ACACatalogTable):
     # Required attributes
     required_attrs = ('att', 'man_angle', 't_ccd_acq', 'date', 'dither_acq')
 
+    dark = MetaAttribute()
     optimize = MetaAttribute(default=True)
     verbose = MetaAttribute(default=False)
 

--- a/proseco/characteristics.py
+++ b/proseco/characteristics.py
@@ -52,7 +52,7 @@ man_errs = p_man_errs['man_err_hi']
 spoiler_star_cols = ['id', 'yang', 'zang', 'row', 'col', 'mag', 'mag_err']
 
 
-bad_pixels = [[-245,0,454,454]]
+bad_pixels = [[-245, 0, 454, 454]]
 
 bad_star_list = [36178592,
                  39980640,

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -738,6 +738,8 @@ def test_acq_fid_catalog_probs_low_level():
     aca = get_aca_catalog(**kwargs)
     acqs = aca.acqs
 
+    assert np.all(acqs.dark == 40)
+
     # Initial fid set is empty () and we check baseline p_safe
     assert acqs.fid_set == ()
     assert np.allclose(np.log10(acqs.calc_p_safe()), -3.75,


### PR DESCRIPTION
`AcqTable` was always getting the dark image from the mica archive even if provided.  This fixes that.

An unrelated PEP8 change is included.