### PR TITLE
Fix regression getting ER ACA catalog; add validation test info

### DIFF
--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -45,11 +45,13 @@ def get_fid_catalog(obsid=0, **kwargs):
     # If no fids are requested then just initialize an empty table
     # here, set the attributes and return the table.  No need to go
     # through the trouble of getting candidate fids.
-    fids = FidTable.empty() if (kwargs.get('n_fid') == 0) else FidTable()
+    fids = FidTable()
     fids.set_attrs_from_kwargs(obsid=obsid, **kwargs)
 
     if fids.n_fid == 0:
-        return fids
+        empty_fids = FidTable.empty()
+        empty_fids.meta = fids.meta
+        return empty_fids
 
     fids.set_stars(acqs=fids.acqs)
 

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -16,6 +16,19 @@ HAS_SC_ARCHIVE = Path(mica.starcheck.starcheck.FILES['data_root']).exists()
 
 
 @pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
+def test_get_aca_catalog_49531():
+    """
+    Test of getting an ER using the mica.starcheck archive for getting the
+    obs parameters.  This tests a regression introduced in the acq-fid
+    functionality.
+    """
+    aca = get_aca_catalog(49531, raise_exc=True)
+    assert len(aca.acqs) == 8
+    assert len(aca.guides) == 8
+    assert len(aca.fids) == 0
+
+
+@pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
 def test_get_aca_catalog_20603():
     """Put it all together.  Regression test for selected stars.
     """


### PR DESCRIPTION
Fixes #114

This includes:
- Fixing the problem with fids and ERs from starcheck
- Cache the call to `get_starcheck_catalog`, since that will normally happen 4 times.
- Add some events to the ACATable log for tracking performance timing
