### PR TITLE
Fix bug including star rejected by spoiler test

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -283,11 +283,6 @@ class AcqTable(ACACatalogTable):
         bads = ~ok
         cand_acqs = stars[ok]
 
-        # If any include_ids (stars forced to be in catalog) ensure that the
-        # star is in the cand_acqs table
-        if self.include_ids:
-            self.add_include_ids(cand_acqs, stars)
-
         cand_acqs.sort('mag')
         self.log('Filtering on CLASS, mag, COLOR1, row/col, '
                  'mag_err, ASPQ1/2, POS_ERR:')
@@ -311,6 +306,12 @@ class AcqTable(ACACatalogTable):
         cand_acqs = cand_acqs[goods]
         self.log('Selected {} candidates with no spoiler (star within 3 mag and 30 arcsec)'
                  .format(len(cand_acqs)))
+
+        # If any include_ids (stars forced to be in catalog) ensure that the
+        # star is in the cand_acqs table.  Need to re-sort as well.
+        if self.include_ids:
+            self.add_include_ids(cand_acqs, stars)
+            cand_acqs.sort('mag')
 
         cand_acqs.rename_column('COLOR1', 'color')
         # Drop all the other AGASC columns.  No longer useful.
@@ -351,6 +352,7 @@ class AcqTable(ACACatalogTable):
                                      f'a valid star in the ACA field of view')
                 else:
                     cand_acqs.add_row(star)
+                    self.log(f'Included star id={include_id} in cand_acqs')
 
     def select_best_p_acqs(self, cand_acqs, min_p_acq, acq_indices, box_sizes):
         """

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -562,11 +562,16 @@ def test_cand_acqs_include_exclude():
                                  id=[9, 10, 11],
                                  size=1500, n_stars=3)
 
+    # Put in a neighboring star that will keep star 9 out of the cand_acqs table
+    star9 = stars.get_id(9)
+    stars.add_fake_star(yang=star9['yang'] + 20, zang=star9['zang'],
+                        mag=star9['mag'] + 2.5, id=90)
+
     # Make sure baseline catalog is working like expected
     acqs = get_acq_catalog(**STD_INFO, optimize=False, stars=stars)
     assert np.all(acqs['id'] == np.arange(1, 9))
     assert np.all(acqs['halfw'] == 160)
-    assert np.all(acqs.cand_acqs['id'] == np.arange(1, 11))
+    assert np.all(acqs.cand_acqs['id'] == [1, 2, 3, 4, 5, 6, 7, 8, 10])
 
     # Define includes and excludes. id=9 is in nominal cand_acqs but not in acqs.
     include_ids = [9, 11]


### PR DESCRIPTION
I discovered in looking at obsid 21069  (and the other two Dragonfly 44 obsids) that this borderline catalog was modified for flight by hand-editing to include a particular star.  Trying to reproduce this in proseco gave an exception because that star was added to the candidate acqs list but then immediately removed because it has a nearby spoilers.  This was a bug in the program logic that is fixed here.

The star 261490008 also was rejected because it has aspq1=24, which is above the limit of 20.  Interesting case...

The modified test failed without the fix in this PR, but passes after.