### PR TITLE
Fix MAG_ACA_ERR units for guide selection

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -381,7 +381,8 @@ def check_mag_spoilers(cand_stars, ok, stars, n_sigma):
                 continue
             if (cand['mag'] - spoil['mag']) < magdifflim:
                 continue
-            mag_err_sum = np.sqrt(cand['MAG_ACA_ERR'] ** 2 + spoil['MAG_ACA_ERR'] ** 2)
+            mag_err_sum = np.sqrt((cand['MAG_ACA_ERR'] * 0.01) ** 2 +
+                                  (spoil['MAG_ACA_ERR'] * 0.01) ** 2)
             delmag = cand['mag'] - spoil['mag'] + n_sigma * mag_err_sum
             thsep = intercept + delmag * spoilslope
             if dist < thsep:
@@ -412,8 +413,9 @@ def check_column_spoilers(cand_stars, ok, stars, n_sigma):
                      (direction > 1.0))
         if not np.count_nonzero(pos_spoil) >= 1:
             continue
-        mag_errs = (n_sigma * np.sqrt(cand['MAG_ACA_ERR'] ** 2 +
-                                      stars['MAG_ACA_ERR'][~stars['offchip']][pos_spoil] ** 2))
+        mag_errs = (n_sigma *
+                    np.sqrt((cand['MAG_ACA_ERR'] * 0.01) ** 2 +
+                            (stars['MAG_ACA_ERR'][~stars['offchip']][pos_spoil] * 0.01) ** 2))
         dm = (cand['mag'] - stars['mag'][~stars['offchip']][pos_spoil] + mag_errs)
         if np.any(dm > GUIDE_CHAR.col_spoiler['MagDiff']):
             column_spoiled[idx] = True

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -25,7 +25,7 @@ def test_select():
     """
     selected = get_guide_catalog(att=(10, 20, 3), date='2018:001', dither=(8, 8),
                                  t_ccd=-13, n_guide=5)
-    expected_star_ids = [156384720, 155980240, 156377856, 156376184, 156381600]
+    expected_star_ids = [156384720, 155980240, 156376184, 156381600, 156379416]
     assert selected['id'].tolist() == expected_star_ids
 
 


### PR DESCRIPTION
Fix MAG_ACA_ERR units for guide selection

I considered adding a new column to the candidate list, but then just used the 0.01 conversion in the two new places that this is used thanks to #105 .

This fix and mag err use in general probably needs more review and better tests, but this might be enough for an updated release candidate for today.

Closes #120