### PR TITLE
Fix issues on linux 32-bit / Windows

### DIFF
--- a/proseco/__init__.py
+++ b/proseco/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2"
+__version__ = "1.2.1"
 
 
 def get_aca_catalog(*args, **kwargs):

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -883,7 +883,7 @@ def calc_p_brightest_compare(acq, mags, mag_errs):
         # CDF is prob that sp_mag < x, so take 1-CDF.
         sp_cdf = stats.norm.cdf(x, loc=mag, scale=mag_err)
         sp_cdfs.append(1 - sp_cdf)
-    prod_sp_cdf = np.prod(sp_cdfs, axis=0)
+    prod_sp_cdf = np.prod(sp_cdfs, axis=0).clip(1e-30)
 
     # Do the integral  ∫ dθ p(θ|t) Πm≠t p(θ<θt|m)
     prob = np.sum(acq_pdf * prod_sp_cdf * dx)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -873,8 +873,8 @@ class StarsTable(ACACatalogTable):
             raise ValueError('max value of n_stars is 8')
 
         ids = len(self) + 100 + np.arange(n_stars)
-        yangs = np.array([1, 0, -1, 0, 0.5, 0.5, -0.5, -0.5][:n_stars]) * size
-        zangs = np.array([0, 1, 0, -1, 0.5, -0.5, 0.5, -0.5][:n_stars]) * size
+        yangs = np.array([1, 0, -1, 0, 0.5, 0.5, -0.5, -0.5][:n_stars], dtype=np.float64) * size
+        zangs = np.array([0, 1, 0, -1, 0.5, -0.5, 0.5, -0.5][:n_stars], dtype=np.float64) * size
 
         arrays = [ids, yangs, zangs, mag]
         names = ['id', 'yang', 'zang', 'mag']


### PR DESCRIPTION
This fixes:

- FloatingPointUnderflow in the probability calculations seen on linux-32
- Int multiply overflow seen on Windows and linux-32 (where default int is 32 bits)

The int multiply overflow is fundamentally an upstream bug fixed in https://github.com/sot/chandra_aca/pull/59, but this test workaround avoids that problem.

The FloatingPointUnderflow is related to multiplying a huge number of small numbers (for imposters), and #118 would probably makes this go away, but the clip() is safe and reasonable.

The version is updated to 1.2.1 in anticipation of a new release.

Passing tests on osx64, linux64, linux32.