### PR TITLE
Script to run starcheck on proseco-generated catalogs

### DIFF
--- a/validate/starcheck_proseco.py
+++ b/validate/starcheck_proseco.py
@@ -1,3 +1,42 @@
+"""
+Do three steps to run starcheck on proseco-generated catalogs for one or more flight weekly loads:
+
+- Copy the flight load products into a local working dir
+- Generate proseco catalogs and update products in place to reflect the new cats
+- Run starcheck
+
+It is assumed the flight load products are in a structure like::
+
+  <load_root>/2018/JUL0218/oflsa  <==  For <load_name> = JUL0218A
+
+The outputs go into a directory like::
+
+  <out_root>/JUL0218A/
+
+Typically this is going to be run from the proseco git repo, using::
+
+  $ ska3
+  $ cd ~/git/proseco
+  $ git checkout <branch/tag>  # If doing run-for-record, be sure to use the release tag
+  $ cd validate
+  $ env PYTHONPATH=$PWD/.. ipython
+  >>> from starcheck_proseco import *
+  >>> run_all()
+  >>> exit()
+
+Publish the results with:
+
+  $ rsync -zarv --prune-empty-dirs --include "*/"  --include="starcheck*" --include="starcheck/*" \
+    --exclude="*" loads/proseco/ /proj/sot/ska/www/ASPECT/proseco/loads/
+
+This whole process is set up to not repeat existing steps (since it is generally slow).
+To re-do things, either completely delete the proseco load directory (probably your best bet),
+or remove:
+
+- 000-proseco   : to re-do updating products
+- starcheck.txt : to re-do starcheck
+"""
+
 from pathlib import Path
 import subprocess
 import shutil
@@ -8,11 +47,50 @@ from proseco.core import get_kwargs_from_starcheck_text
 import Ska.File
 
 
-def copy_load_products(load_name, out_root, load_root=None):
-    # Default location of loads on HEAD network
-    if load_root is None:
-        load_root = '/data/mpcrit1/mplogs'
+def run_starcheck_proseco(load_name='JUL0218A',
+                          out_root=Path('loads', 'proseco'),
+                          load_root=Path('/data', 'mpcrit1', 'mplogs')):
+    """
+    Do three steps to run starcheck on proseco-generated catalogs for a flight weekly load:
 
+    - Copy the flight load products into a local working dir
+    - Generate proseco catalogs and update products in place to reflect the new cats
+    - Run starcheck
+
+    It is assumed the flight load products are in a structure like::
+
+      <load_root>/2018/JUL0218/oflsa  <==  For JUL0218A
+
+    :param load_name: Load name like JUL0218A
+    :param out_root: Output root, where results go into <out_door>/<load_name>
+    :param load_root: Source root for load products (default=/data/mpcrit1/mplogs)
+    """
+    copy_load_products(load_name, out_root, load_root)
+    update_products(load_name, out_root)
+    run_starcheck(load_name, out_root)
+
+
+def run_all(out_root=Path('loads', 'proseco')):
+    """
+    Convenience function to run starcheck_proseco on a standard set of 10 weekly loads
+    for run-for-record validation testing.
+    """
+    load_names = ['JUL0918A',  # dark cals
+                  'JUL0218A',
+                  'JUN2318A',
+                  'JUN1118A',
+                  'JUN0418A',
+                  'MAY2118A',
+                  'MAY1418A',
+                  'MAY0718A',
+                  'APR3018A',
+                  'APR1618A',
+                  'APR2318C']
+    for load_name in load_names:
+        run_starcheck_proseco(load_name)
+
+
+def copy_load_products(load_name, out_root, load_root):
     out_dir = Path(out_root, load_name)
     if out_dir.exists():
         print(f'Skipping copy_load_products {out_dir} already exists')
@@ -118,27 +196,3 @@ def run_starcheck(load_name, out_root):
     print(f'Running starcheck in {load_dir}')
     with Ska.File.chdir(str(load_dir)):
         subprocess.run(['bash', '/proj/sot/ska/bin/starcheck'])
-
-
-def run_starcheck_proseco(load_name='JUL0218A',
-                          out_root=Path('loads', 'proseco'),
-                          load_root=None):
-    copy_load_products(load_name, out_root, load_root)
-    update_products(load_name, out_root)
-    run_starcheck(load_name, out_root)
-
-
-def run_all(out_root='loads'):
-    load_names = ['JUL0918A',  # dark cals
-                  'JUL0218A',
-                  'JUN2318A',
-                  'JUN1118A',
-                  'JUN0418A',
-                  'MAY2118A',
-                  'MAY1418A',
-                  'MAY0718A',
-                  'APR3018A',
-                  'APR1618A',
-                  'APR2318C']
-    for load_name in load_names:
-        run_starcheck_proseco(load_name)

--- a/validate/starcheck_proseco.py
+++ b/validate/starcheck_proseco.py
@@ -1,0 +1,191 @@
+import subprocess
+from pathlib import Path
+import shutil
+
+import numpy as np
+import parse_cm
+from mica.starcheck import get_starcat
+from proseco.acq import get_acq_catalog
+import Ska.File
+
+
+def copy_load_products(load_name, out_root,
+                       load_root='/data/mpcrit1/mplogs'):
+    out_dir = Path(out_root) / load_name
+    if out_dir.exists():
+        print(f'Skipping copy_load_products {out_dir} already exists')
+        return
+
+    load_root = Path(load_root)
+    load_version = load_name[-1:].lower()
+    load_year = '20' + load_name[-3:-1]
+
+    load_dir = load_root / load_year / load_name[:-1] / ('ofls' + load_version)
+    print(f'Copying load products from {load_dir} to {out_dir}')
+
+    globs = ('CR*.tlr',
+             'CR*.backstop',
+             'mps/md*.dot',
+             'mps/or/*.or',
+             'mps/ode/characteristics/CHARACTERIS_*',
+             'mps/m*.sum',
+             'output/*_ManErr.txt',
+             'output/*_dynamical_offsets.txt',
+             'output/TEST_mechcheck.txt',
+             'History/DITHER.txt',
+             'History/FIDSEL.txt',
+             'History/RADMON.txt',
+             'History/SIMFOCUS.txt',
+             'History/SIMTRANS.txt')
+
+    for glob in globs:
+        for src in load_dir.glob(glob):
+            dest = out_dir / src.relative_to(load_dir)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+
+
+def merge_cats(cat, pcat):
+    """
+    Merge the proseco acq star catalog ``pcat`` into the mica starcat
+    catalog ``cat``.
+    """
+    cat = cat.copy()
+
+    for star in cat:
+        if star['type'] in ('BOT', 'GUI'):
+            size = star['sz']
+            break
+
+    # First remove existing acq stars in `cat`
+    for idx, star in enumerate(cat):
+        if star['type'] == 'BOT':
+            star['type'] = 'GUI'
+            star['dim'] = 1
+            star['halfw'] = 25
+
+    cat = cat[cat['type'] != 'ACQ']
+
+    cat['idx'] = np.arange(len(cat))
+
+    # Find existing GUI stars for possible upgrade to BOT
+    gui_idxs = {star['id']: idx for idx, star in enumerate(cat)
+                if star['type'] == 'GUI'}
+
+    # Keep track of available slots for an acq star
+    acq_slots = list(range(8))
+
+    for acq in pcat:
+        if acq['id'] in gui_idxs:
+            # In-place update of existing GUI row
+            star = cat[gui_idxs[acq['id']]]
+            star['type'] = 'BOT'
+            star['dim'] = (acq['halfw'] - 20) / 5
+            star['halfw'] = acq['halfw']
+            star['pass'] = 'P'
+            # Mark acq_slot as being used
+            acq_slots.remove(star['slot'])
+
+    for acq in pcat:
+        if acq['id'] not in gui_idxs:
+            # Add a row for ACQ star
+            cat0 = cat[0]
+            star = {name: cat0[name] for name in cat.colnames}
+            star['id'] = acq['id']
+            star['idx'] = len(cat)
+            star['yang'] = acq['yang']
+            star['zang'] = acq['zang']
+            star['type'] = 'ACQ'
+            star['dim'] = (acq['halfw'] - 20) / 5
+            star['halfw'] = acq['halfw']
+            star['pass'] = 'P'
+            star['slot'] = acq_slots.pop(0)
+            star['mag'] = acq['mag']
+            star['minmag'] = max(acq['mag'] - 1.5, 5.8)
+            star['maxmag'] = acq['mag'] + 1.5
+            star['sz'] = size
+            cat.add_row(star)
+
+    # Finally sort
+    cat['typ'] = 0
+    for idx, typ in enumerate(('FID', 'BOT', 'GUI', 'ACQ', 'MON')):
+        ok = cat['type'] == typ
+        cat['typ'][ok] = idx
+    cat.sort('typ')
+    del cat['typ']
+    cat['idx'] = np.arange(len(cat))
+
+    return cat
+
+
+def update_products(load_name, outroot):
+    load_dir = Path(outroot) / load_name
+    touch_file = load_dir / '000-proseco'
+    if touch_file.exists():
+        print('Skipping update products, already done')
+        return
+
+    gspath = list(load_dir.glob('mps/mg*.sum'))[0]
+    bspath = list(load_dir.glob('CR*.backstop'))[0]
+    dotpath = list(load_dir.glob('mps/md*.dot'))[0]
+
+    gs = parse_cm.read_guide_summary(gspath)
+    bs = parse_cm.read_backstop(bspath)
+    dt = parse_cm.read_dot_as_list(dotpath)
+
+    obsids = [summ['obsid'] for summ in gs['summs']]
+
+    mcats = {}
+    for obsid in obsids:
+        print('Getting starcat for obsid {}'.format(obsid))
+        cat = get_starcat(obsid)
+        print('  Generating proseco catalog and merging')
+        pcat = get_acq_catalog(obsid)
+        mcats[obsid] = merge_cats(cat, pcat)
+
+    print('Updating backstop, DOT and guide summary products')
+    gs = parse_cm.replace_starcat_guide_summary(gs, mcats)
+    bs = parse_cm.replace_starcat_backstop(bs, mcats)
+    dt = parse_cm.replace_starcat_dot(dt, mcats)
+
+    print('Writing ...')
+    parse_cm.write_guide_summary(gs, gspath)
+    parse_cm.write_backstop(bs, bspath)
+    parse_cm.write_dot(dt, dotpath)
+
+    touch_file.touch()
+
+
+def run_starcheck(load_name, outroot):
+    load_dir = Path(outroot) / load_name
+    starcheck_txt = load_dir / 'starcheck.txt'
+    if starcheck_txt.exists():
+        print(f'Skipping because {starcheck_txt} already exists')
+        return
+    print(f'Running starcheck in {load_dir}')
+    with Ska.File.chdir(str(load_dir)):
+        subprocess.run(['bash', '/proj/sot/ska/bin/starcheck'])
+
+
+def run_starcheck_proseco(load_name='JUL0218A', outroot='test_loads'):
+    copy_load_products(load_name, outroot)
+    update_products(load_name, outroot)
+    run_starcheck(load_name, outroot)
+
+
+def run_all(outroot='test_loads'):
+    load_names = ['JUL0918A',  # dark cals
+                  'JUL0218A',
+                  'JUN2318A',
+                  # 'JUN1818A',  ??
+                  'JUN1118A',
+                  'JUN0418A',
+                  # 'MAY2818A',  no pred_temp for 20293
+                  'MAY2118A',
+                  'MAY1418A',
+                  'MAY0718A',
+                  'APR3018A',
+                  'APR1618A',
+                  'APR2318C']
+    for load_name in load_names:
+        run_starcheck_proseco(load_name)

--- a/validate/starcheck_proseco.py
+++ b/validate/starcheck_proseco.py
@@ -189,9 +189,9 @@ def update_products(load_name, out_root):
 
 def run_starcheck(load_name, out_root):
     load_dir = Path(out_root, load_name)
-    starcheck_txt = load_dir / 'starcheck.txt'
-    if starcheck_txt.exists():
-        print(f'Skipping because {starcheck_txt} already exists')
+    starcheck_html = load_dir / 'starcheck.html'
+    if starcheck_html.exists():
+        print(f'Skipping because {starcheck_html} already exists')
         return
     print(f'Running starcheck in {load_dir}')
     with Ska.File.chdir(str(load_dir)):

--- a/validate/starcheck_proseco.py
+++ b/validate/starcheck_proseco.py
@@ -1,17 +1,19 @@
-import subprocess
 from pathlib import Path
+import subprocess
 import shutil
 
-import numpy as np
 import parse_cm
-from mica.starcheck import get_starcat
-from proseco.acq import get_acq_catalog
+from proseco import get_aca_catalog
+from proseco.core import get_kwargs_from_starcheck_text
 import Ska.File
 
 
-def copy_load_products(load_name, out_root,
-                       load_root='/data/mpcrit1/mplogs'):
-    out_dir = Path(out_root) / load_name
+def copy_load_products(load_name, out_root, load_root=None):
+    # Default location of loads on HEAD network
+    if load_root is None:
+        load_root = '/data/mpcrit1/mplogs'
+
+    out_dir = Path(out_root, load_name)
     if out_dir.exists():
         print(f'Skipping copy_load_products {out_dir} already exists')
         return
@@ -25,6 +27,7 @@ def copy_load_products(load_name, out_root,
 
     globs = ('CR*.tlr',
              'CR*.backstop',
+             'starcheck.txt',
              'mps/md*.dot',
              'mps/or/*.or',
              'mps/ode/characteristics/CHARACTERIS_*',
@@ -45,81 +48,34 @@ def copy_load_products(load_name, out_root,
             shutil.copy2(src, dest)
 
 
-def merge_cats(cat, pcat):
+def get_starcheck_obs_kwargs(filename):
     """
-    Merge the proseco acq star catalog ``pcat`` into the mica starcat
-    catalog ``cat``.
+    Parse the starcheck.txt file to get keyword arg dicts for get_aca_catalog()
+
+    :param filename: file name of starcheck.txt in load products
+    :returns: dict (by obsid) of kwargs for get_aca_catalog()
+
     """
-    cat = cat.copy()
+    delim = "==================================================================================== "
+    with open(filename, 'r') as fh:
+        text = fh.read()
+    chunks = text.split(delim)
+    outs = {}
+    for chunk in chunks:
+        if "No star catalog for obsid" in chunk:
+            continue
+        try:
+            out = get_kwargs_from_starcheck_text(chunk)
+        except ValueError:
+            continue
+        else:
+            outs[out['obsid']] = out
 
-    for star in cat:
-        if star['type'] in ('BOT', 'GUI'):
-            size = star['sz']
-            break
-
-    # First remove existing acq stars in `cat`
-    for idx, star in enumerate(cat):
-        if star['type'] == 'BOT':
-            star['type'] = 'GUI'
-            star['dim'] = 1
-            star['halfw'] = 25
-
-    cat = cat[cat['type'] != 'ACQ']
-
-    cat['idx'] = np.arange(len(cat))
-
-    # Find existing GUI stars for possible upgrade to BOT
-    gui_idxs = {star['id']: idx for idx, star in enumerate(cat)
-                if star['type'] == 'GUI'}
-
-    # Keep track of available slots for an acq star
-    acq_slots = list(range(8))
-
-    for acq in pcat:
-        if acq['id'] in gui_idxs:
-            # In-place update of existing GUI row
-            star = cat[gui_idxs[acq['id']]]
-            star['type'] = 'BOT'
-            star['dim'] = (acq['halfw'] - 20) / 5
-            star['halfw'] = acq['halfw']
-            star['pass'] = 'P'
-            # Mark acq_slot as being used
-            acq_slots.remove(star['slot'])
-
-    for acq in pcat:
-        if acq['id'] not in gui_idxs:
-            # Add a row for ACQ star
-            cat0 = cat[0]
-            star = {name: cat0[name] for name in cat.colnames}
-            star['id'] = acq['id']
-            star['idx'] = len(cat)
-            star['yang'] = acq['yang']
-            star['zang'] = acq['zang']
-            star['type'] = 'ACQ'
-            star['dim'] = (acq['halfw'] - 20) / 5
-            star['halfw'] = acq['halfw']
-            star['pass'] = 'P'
-            star['slot'] = acq_slots.pop(0)
-            star['mag'] = acq['mag']
-            star['minmag'] = max(acq['mag'] - 1.5, 5.8)
-            star['maxmag'] = acq['mag'] + 1.5
-            star['sz'] = size
-            cat.add_row(star)
-
-    # Finally sort
-    cat['typ'] = 0
-    for idx, typ in enumerate(('FID', 'BOT', 'GUI', 'ACQ', 'MON')):
-        ok = cat['type'] == typ
-        cat['typ'][ok] = idx
-    cat.sort('typ')
-    del cat['typ']
-    cat['idx'] = np.arange(len(cat))
-
-    return cat
+    return outs
 
 
-def update_products(load_name, outroot):
-    load_dir = Path(outroot) / load_name
+def update_products(load_name, out_root):
+    load_dir = Path(out_root) / load_name
     touch_file = load_dir / '000-proseco'
     if touch_file.exists():
         print('Skipping update products, already done')
@@ -129,24 +85,21 @@ def update_products(load_name, outroot):
     bspath = list(load_dir.glob('CR*.backstop'))[0]
     dotpath = list(load_dir.glob('mps/md*.dot'))[0]
 
+    obs_kwargs = get_starcheck_obs_kwargs(load_dir / 'starcheck.txt')
+
     gs = parse_cm.read_guide_summary(gspath)
     bs = parse_cm.read_backstop(bspath)
     dt = parse_cm.read_dot_as_list(dotpath)
 
-    obsids = [summ['obsid'] for summ in gs['summs']]
-
-    mcats = {}
-    for obsid in obsids:
-        print('Getting starcat for obsid {}'.format(obsid))
-        cat = get_starcat(obsid)
-        print('  Generating proseco catalog and merging')
-        pcat = get_acq_catalog(obsid)
-        mcats[obsid] = merge_cats(cat, pcat)
+    cats = {}
+    for obsid, kwargs in obs_kwargs.items():
+        print(f'  Generating proseco catalog for {obsid}')
+        cats[obsid] = get_aca_catalog(raise_exc=True, **kwargs)
 
     print('Updating backstop, DOT and guide summary products')
-    gs = parse_cm.replace_starcat_guide_summary(gs, mcats)
-    bs = parse_cm.replace_starcat_backstop(bs, mcats)
-    dt = parse_cm.replace_starcat_dot(dt, mcats)
+    gs = parse_cm.replace_starcat_guide_summary(gs, cats)
+    bs = parse_cm.replace_starcat_backstop(bs, cats)
+    dt = parse_cm.replace_starcat_dot(dt, cats)
 
     print('Writing ...')
     parse_cm.write_guide_summary(gs, gspath)
@@ -156,8 +109,8 @@ def update_products(load_name, outroot):
     touch_file.touch()
 
 
-def run_starcheck(load_name, outroot):
-    load_dir = Path(outroot) / load_name
+def run_starcheck(load_name, out_root):
+    load_dir = Path(out_root, load_name)
     starcheck_txt = load_dir / 'starcheck.txt'
     if starcheck_txt.exists():
         print(f'Skipping because {starcheck_txt} already exists')
@@ -167,20 +120,20 @@ def run_starcheck(load_name, outroot):
         subprocess.run(['bash', '/proj/sot/ska/bin/starcheck'])
 
 
-def run_starcheck_proseco(load_name='JUL0218A', outroot='test_loads'):
-    copy_load_products(load_name, outroot)
-    update_products(load_name, outroot)
-    run_starcheck(load_name, outroot)
+def run_starcheck_proseco(load_name='JUL0218A',
+                          out_root=Path('loads', 'proseco'),
+                          load_root=None):
+    copy_load_products(load_name, out_root, load_root)
+    update_products(load_name, out_root)
+    run_starcheck(load_name, out_root)
 
 
-def run_all(outroot='test_loads'):
+def run_all(out_root='loads'):
     load_names = ['JUL0918A',  # dark cals
                   'JUL0218A',
                   'JUN2318A',
-                  # 'JUN1818A',  ??
                   'JUN1118A',
                   'JUN0418A',
-                  # 'MAY2818A',  no pred_temp for 20293
                   'MAY2118A',
                   'MAY1418A',
                   'MAY0718A',


### PR DESCRIPTION
This incorporates the script I used to generate products for the catalogs shown in StarWorkingGroupMeeting2018x07x18.  

To do:

- [x] The merge catalogs function is redundant with what is in `catalog.py` now, so probably take it out.
- [x] Deal with guide and fid which now come from proseco also.
- [x] @jeanconn apparently wrote something similar, so reconcile the two.

The new `validate` is a fine place to dump notebooks in progress and put on a branch for visibility on github.  Most likely will not merge though.