### PR TITLE
 Improve pickle handling by controlling in MetaAttribute

### DIFF
--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -55,6 +55,9 @@ def test_get_aca_catalog_20603():
     repr(aca)  # Apply default formats
     assert aca[TEST_COLS].pformat(max_width=-1) == exp
 
+    aca_pkl = pickle.dumps(aca)
+    assert len(aca_pkl) < 180_000  # Nominally ~170k, warn if size grows
+
 
 @pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
 def test_get_aca_catalog_20259():


### PR DESCRIPTION
#141 accidentally made the `dark` attribute be one which gets pickled.  This reworks that aspect of processing to control the pickling of an attribute with `MetaAttribute`.  And of course it sets `stars` and `dark` to not get pickled.

It also adds a regression test to prevent unexpected pickle blowouts.

Fixes #145.
