### PR TITLE
Add calc_spoiler_impact function and use instead of box filter for acq

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -80,7 +80,7 @@ def calc_spoiler_impact(star, stars):
 
     s_rows = stars['row']
     s_cols = stars['col']
-    s_norms = mag_to_count_rate(stars['mag'])
+    s_mags = stars['mag']
 
     ok = ((np.abs(s_rows - row) < 7) &
           (np.abs(s_cols - col) < 7) &
@@ -94,7 +94,8 @@ def calc_spoiler_impact(star, stars):
     bgd = get_bgd(np_img)
     row0, col0, norm0 = img.centroid_fm(bgd=bgd)
 
-    for s_row, s_col, s_norm in zip(s_rows[ok], s_cols[ok], s_norms[ok]):
+    for s_row, s_col, s_norm in zip(s_rows[ok], s_cols[ok],
+                                    mag_to_count_rate(s_mags[ok])):
         s_img = APL.get_psf_image(row=s_row, col=s_col, norm=s_norm)
         img += s_img.aca
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -82,8 +82,8 @@ def calc_spoiler_impact(star, stars):
     s_cols = stars['col']
     s_mags = stars['mag']
 
-    ok = ((np.abs(s_rows - row) < 7) &
-          (np.abs(s_cols - col) < 7) &
+    ok = ((np.abs(s_rows - row) < 9) &
+          (np.abs(s_cols - col) < 9) &
           (star['id'] != stars['id']))
     if not np.any(ok):
         return 0.0, 0.0, 1.0

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -59,7 +59,7 @@ COLB = np.array([0, 1, 6, 7, 0, 1, 6, 7])
 
 
 def get_bgd(img):
-    bgds = np.sort(img[ROWB, COLB])
+    bgds = np.sort(np.array(img)[ROWB, COLB])
     bgd = (bgds[6] + bgds[7]) / 2
     return bgd
 
@@ -82,16 +82,17 @@ def calc_spoiler_impact(star, stars):
     s_cols = stars['col']
     s_mags = stars['mag']
 
+    # Find potential spoilers with centroid within a 9-pixel halfw box
     ok = ((np.abs(s_rows - row) < 9) &
           (np.abs(s_cols - col) < 9) &
           (star['id'] != stars['id']))
     if not np.any(ok):
         return 0.0, 0.0, 1.0
 
+    # Make an image of the candidate star
     img = APL.get_psf_image(row=row, col=col, norm=norm)
-    np_img = np.array(img, copy=False)
 
-    bgd = get_bgd(np_img)
+    bgd = get_bgd(img)
     row0, col0, norm0 = img.centroid_fm(bgd=bgd)
 
     for s_row, s_col, s_norm in zip(s_rows[ok], s_cols[ok],
@@ -99,7 +100,7 @@ def calc_spoiler_impact(star, stars):
         s_img = APL.get_psf_image(row=s_row, col=s_col, norm=s_norm)
         img += s_img.aca
 
-    bgd = get_bgd(np_img)
+    bgd = get_bgd(img)
     try:
         row1, col1, norm1 = img.centroid_fm(bgd=bgd)
     except ValueError as err:

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -99,7 +99,8 @@ class FidTable(ACACatalogTable):
         if self.n_fid == 0:
             out = 1
         else:
-            out = int(len(self) == self.n_fid)
+            out = int(len(self) == self.n_fid and  # Requested number of fids
+                      self['spoiler_score'].sum() < 4)  # No red fid warnings
         return out
 
     def set_fid_set(self, fid_ids):

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -567,7 +567,8 @@ def test_cand_acqs_include_exclude():
 
     # Put in a neighboring star that will keep star 9 out of the cand_acqs table
     star9 = stars.get_id(9)
-    stars.add_fake_star(yang=star9['yang'] + 20, zang=star9['zang'],
+    star9['ASPQ1'] = 20
+    stars.add_fake_star(yang=star9['yang'] + 20, zang=star9['zang'] + 20,
                         mag=star9['mag'] + 2.5, id=90)
 
     # Make sure baseline catalog is working like expected


### PR DESCRIPTION
This computes the centroid offset and fractional change in summed counts caused by spoilers.
It runs in about 1 msec for a single spoiler. 

To do:
- [x] Unit tests with synthetic values to demonstrate expected behavior
- [x] Add 21068 functional test
- [x] Fix current breaking test (include_exclude).
- [x] Code comments