### PR TITLE
Add option to update_products to use proseco pkl file for cats

### DIFF
--- a/validate/starcheck_proseco.py
+++ b/validate/starcheck_proseco.py
@@ -40,6 +40,7 @@ or remove:
 from pathlib import Path
 import subprocess
 import shutil
+import pickle
 
 import parse_cm
 from proseco import get_aca_catalog
@@ -152,7 +153,7 @@ def get_starcheck_obs_kwargs(filename):
     return outs
 
 
-def update_products(load_name, out_root):
+def update_products(load_name, out_root, orv_pickle=None):
     load_dir = Path(out_root) / load_name
     touch_file = load_dir / '000-proseco'
     if touch_file.exists():
@@ -163,16 +164,25 @@ def update_products(load_name, out_root):
     bspath = list(load_dir.glob('CR*.backstop'))[0]
     dotpath = list(load_dir.glob('mps/md*.dot'))[0]
 
-    obs_kwargs = get_starcheck_obs_kwargs(load_dir / 'starcheck.txt')
-
     gs = parse_cm.read_guide_summary(gspath)
     bs = parse_cm.read_backstop(bspath)
     dt = parse_cm.read_dot_as_list(dotpath)
 
-    cats = {}
-    for obsid, kwargs in obs_kwargs.items():
-        print(f'  Generating proseco catalog for {obsid}')
-        cats[obsid] = get_aca_catalog(raise_exc=True, **kwargs)
+    if orv_pickle is None:
+        obs_kwargs = get_starcheck_obs_kwargs(load_dir / 'starcheck.txt')
+        cats = {}
+        for obsid, kwargs in obs_kwargs.items():
+            print(f'  Generating proseco catalog for {obsid}')
+            cats[obsid] = get_aca_catalog(raise_exc=True, **kwargs)
+    else:
+        orvcats = pickle.load(open(orv_pickle, 'rb'))
+        # The ORV proseco pickle uses strings as the keys, so int them
+        cats = {int(k): v for k, v in orvcats.items()}
+        # It looks like the proseco pickle has catalogs for no-catalog
+        # observations (dark cal), so trim those
+        extras = set(cats.keys()) - set([summ['obsid'] for summ in gs['summs']])
+        for obs in extras:
+            del cats[obs]
 
     print('Updating backstop, DOT and guide summary products')
     gs = parse_cm.replace_starcat_guide_summary(gs, cats)


### PR DESCRIPTION
Add option to update_products to use proseco pkl file for cats

The idea is that the pkl file from ORViewer could be used as the source for the stubbing in of catalogs.  From ORViewer I also already have the updated DOT and guide summary, but am ignoring them for now.

This doesn't immediately work with the "run_all" idea, and is designed for manual calls to update_products.