### PR TITLE
Add API and attr support for include/exclude stars for guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,14 +51,16 @@ focus_offset  SIM focus offset [steps] (default=0)
 
 **Optional**
 
-============== =========================================================
-Argument       Description
-============== =========================================================
-include_ids    list of AGASC IDs of stars to include in selected catalog
-include_halfws list of acq halfwidths corresponding to ``include_ids``
-exclude_ids    list of AGASC IDs of stars to exclude from selected catalog
-stars          table of AGASC stars (will be fetched from agasc if None)
-============== =========================================================
+=================== =========================================================
+Argument            Description
+=================== =========================================================
+include_ids_acq     list of AGASC IDs of stars to include in acq catalog
+include_halfws_acq  list of acq halfwidths corresponding to ``include_ids``
+exclude_ids_acq     list of AGASC IDs of stars to exclude from acq catalog
+include_ids_guide   list of AGASC IDs of stars to include in guide catalog
+exclude_ids_guide   list of AGASC IDs of stars to exclude from guide catalog
+stars               table of AGASC stars (will be fetched from agasc if None)
+=================== =========================================================
 
 **Debug**
 

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -155,6 +155,30 @@ class AcqTable(ACACatalogTable):
         self.dither_acq = value
 
     @property
+    def include_ids(self):
+        return self.include_ids_acq
+
+    @include_ids.setter
+    def include_ids(self, value):
+        self.include_ids_acq = value
+
+    @property
+    def include_halfws(self):
+        return self.include_halfws_acq
+
+    @include_halfws.setter
+    def include_halfws(self, value):
+        self.include_halfws_acq = value
+
+    @property
+    def exclude_ids(self):
+        return self.exclude_ids_acq
+
+    @exclude_ids.setter
+    def exclude_ids(self, value):
+        self.exclude_ids_acq = value
+
+    @property
     def fid_set(self):
         if not hasattr(self, '_fid_set'):
             self._fid_set = ()

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -18,7 +18,7 @@ from chandra_aca.transform import (pixels_to_yagzag, mag_to_count_rate,
 from . import characteristics as CHAR
 from .core import (get_mag_std, ACACatalogTable, bin2x2,
                    get_image_props, pea_reject_image, ACABox,
-                   MetaAttribute, calc_spoiler_impact)
+                   MetaAttribute, AliasAttribute, calc_spoiler_impact)
 
 
 def get_acq_catalog(obsid=0, **kwargs):
@@ -138,45 +138,11 @@ class AcqTable(ACACatalogTable):
         out['halfw'] = np.full(fill_value=0, shape=(0,), dtype=np.int64)
         return out
 
-    @property
-    def t_ccd(self):
-        return self.t_ccd_acq
-
-    @t_ccd.setter
-    def t_ccd(self, value):
-        self.t_ccd_acq = value
-
-    @property
-    def dither(self):
-        return self.dither_acq
-
-    @dither.setter
-    def dither(self, value):
-        self.dither_acq = value
-
-    @property
-    def include_ids(self):
-        return self.include_ids_acq
-
-    @include_ids.setter
-    def include_ids(self, value):
-        self.include_ids_acq = value
-
-    @property
-    def include_halfws(self):
-        return self.include_halfws_acq
-
-    @include_halfws.setter
-    def include_halfws(self, value):
-        self.include_halfws_acq = value
-
-    @property
-    def exclude_ids(self):
-        return self.exclude_ids_acq
-
-    @exclude_ids.setter
-    def exclude_ids(self, value):
-        self.exclude_ids_acq = value
+    t_ccd = AliasAttribute()
+    dither = AliasAttribute()
+    include_ids = AliasAttribute()
+    include_halfws = AliasAttribute()
+    exclude_ids = AliasAttribute()
 
     @property
     def fid_set(self):

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -34,9 +34,9 @@ def get_aca_catalog(obsid=0, **kwargs):
     :param sim_offset: SIM translation offset from nominal [steps] (default=0)
     :param focus_offset: SIM focus offset [steps] (default=0)
     :param stars: table of AGASC stars (will be fetched from agasc if None)
-    :param include_ids: list of AGASC IDs of stars to include in selected catalog
-    :param include_halfws: list of acq halfwidths corresponding to ``include_ids``
-    :param exclude_ids: list of AGASC IDs of stars to exclude from selected catalog
+    :param include_ids_acq: list of AGASC IDs of stars to include in acq catalog
+    :param include_halfws_acq: list of acq halfwidths corresponding to ``include_ids``
+    :param exclude_ids_acq: list of AGASC IDs of stars to exclude from acq catalog
     :param optimize: optimize star catalog after initial selection (default=True)
     :param verbose: provide extra logging info (mostly calc_p_safe) (default=False)
     :param print_log: print the run log to stdout (default=False)

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -37,6 +37,8 @@ def get_aca_catalog(obsid=0, **kwargs):
     :param include_ids_acq: list of AGASC IDs of stars to include in acq catalog
     :param include_halfws_acq: list of acq halfwidths corresponding to ``include_ids``
     :param exclude_ids_acq: list of AGASC IDs of stars to exclude from acq catalog
+    :param include_ids_guide: list of AGASC IDs of stars to include in guide catalog
+    :param exclude_ids_guide: list of AGASC IDs of stars to exclude from guide catalog
     :param optimize: optimize star catalog after initial selection (default=True)
     :param verbose: provide extra logging info (mostly calc_p_safe) (default=False)
     :param print_log: print the run log to stdout (default=False)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -315,6 +315,8 @@ class ACACatalogTable(Table):
     include_ids_acq = MetaAttribute(default=[])
     include_halfws_acq = MetaAttribute(default=[])
     exclude_ids_acq = MetaAttribute(default=[])
+    include_ids_guide = MetaAttribute(default=[])
+    exclude_ids_guide = MetaAttribute(default=[])
     optimize = MetaAttribute(default=True)
     verbose = MetaAttribute(default=False)
     print_log = MetaAttribute(default=False)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -291,7 +291,8 @@ class ACACatalogTable(Table):
     name = 'aca_cat'
 
     # Catalog attributes, gets set in MetaAttribute
-    allowed_kwargs = set(['dither', 't_ccd'])
+    allowed_kwargs = set(['dither', 't_ccd',
+                          'include_ids', 'include_halfws', 'exclude_ids'])
 
     required_attrs = ('dither_acq', 'dither_guide', 'date')
 
@@ -311,9 +312,9 @@ class ACACatalogTable(Table):
     focus_offset = MetaAttribute()
     dark = MetaAttribute(pickle=False)
     stars = MetaAttribute(pickle=False)
-    include_ids = MetaAttribute(default=[])
-    include_halfws = MetaAttribute(default=[])
-    exclude_ids = MetaAttribute(default=[])
+    include_ids_acq = MetaAttribute(default=[])
+    include_halfws_acq = MetaAttribute(default=[])
+    exclude_ids_acq = MetaAttribute(default=[])
     optimize = MetaAttribute(default=True)
     verbose = MetaAttribute(default=False)
     print_log = MetaAttribute(default=False)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -257,6 +257,7 @@ class AliasAttribute:
     def __set_name__(self, owner, name):
         if owner.__name__.endswith('Table'):
             self.alias = name + '_' + owner.__name__[:-5].lower()
+            owner.allowed_kwargs.add(name)
         else:
             raise ValueError('can only be used in classes named *Table')
 
@@ -327,9 +328,8 @@ class ACACatalogTable(Table):
     # Should be set by subclass, e.g. ``name = 'acqs'`` for AcqTable.
     name = 'aca_cat'
 
-    # Catalog attributes, gets set in MetaAttribute
-    allowed_kwargs = set(['dither', 't_ccd',
-                          'include_ids', 'include_halfws', 'exclude_ids'])
+    # Catalog attributes, gets set in MetaAttribute or AliasAttribute
+    allowed_kwargs = set()
 
     required_attrs = ('dither_acq', 'dither_guide', 'date')
 

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -11,7 +11,7 @@ from chandra_aca.star_probs import guide_count
 from . import characteristics as CHAR
 from . import characteristics_guide as GUIDE_CHAR
 
-from .core import bin2x2, ACACatalogTable, ACABox, MetaAttribute
+from .core import bin2x2, ACACatalogTable, MetaAttribute, AliasAttribute
 
 CCD = GUIDE_CHAR.CCD
 
@@ -88,37 +88,10 @@ class GuideTable(ACACatalogTable):
         reject_info = self.reject_info
         reject_info.append(reject)
 
-    @property
-    def t_ccd(self):
-        return self.t_ccd_guide
-
-    @t_ccd.setter
-    def t_ccd(self, value):
-        self.t_ccd_guide = value
-
-    @property
-    def dither(self):
-        return self.dither_guide
-
-    @dither.setter
-    def dither(self, value):
-        self.dither_guide = value
-
-    @property
-    def include_ids(self):
-        return self.include_ids_guide
-
-    @include_ids.setter
-    def include_ids(self, value):
-        self.include_ids_guide = value
-
-    @property
-    def exclude_ids(self):
-        return self.exclude_ids_guide
-
-    @exclude_ids.setter
-    def exclude_ids(self, value):
-        self.exclude_ids_guide = value
+    t_ccd = AliasAttribute()
+    dither = AliasAttribute()
+    include_ids = AliasAttribute()
+    exclude_ids = AliasAttribute()
 
     @property
     def thumbs_up(self):
@@ -367,7 +340,6 @@ class GuideTable(ACACatalogTable):
         return cand_guides
 
 
-
 def check_fid_trap(cand_stars, fids, dither):
     """
     Search for guide stars that would cause the fid trap issue and mark as spoilers.
@@ -385,7 +357,7 @@ def check_fid_trap(cand_stars, fids, dither):
         return spoilers, []
 
     bad_row = GUIDE_CHAR.fid_trap['row']
-    bad_col= GUIDE_CHAR.fid_trap['col']
+    bad_col = GUIDE_CHAR.fid_trap['col']
     fid_margin = GUIDE_CHAR.fid_trap['margin']
 
     # Check to see if the fid is in the zone that's a problem for the trap and if there's

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -103,6 +103,22 @@ class GuideTable(ACACatalogTable):
         self.dither_guide = value
 
     @property
+    def include_ids(self):
+        return self.include_ids_guide
+
+    @include_ids.setter
+    def include_ids(self, value):
+        self.include_ids_guide = value
+
+    @property
+    def exclude_ids(self):
+        return self.exclude_ids_guide
+
+    @exclude_ids.setter
+    def exclude_ids(self, value):
+        self.exclude_ids_guide = value
+
+    @property
     def thumbs_up(self):
         if self.n_guide == 0:
             # If no guides were requested then always OK

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -32,6 +32,8 @@ def get_guide_catalog(obsid=0, **kwargs):
     :param n_guide: number of guide stars to attempt to get
     :param fids: selected fids (used for guide star exclusion)
     :param stars: astropy.Table of AGASC stars (will be fetched from agasc if None)
+    :param include_ids: list of AGASC IDs of stars to include in guide catalog
+    :param exclude_ids: list of AGASC IDs of stars to exclude from guide catalog
     :param dark: ACAImage of dark map (fetched based on time and t_ccd if None)
     :param print_log: print the run log to stdout (default=False)
 


### PR DESCRIPTION
This makes it possible to specify a list of stars to specifically include or exclude for both acq and guide catalogs.  This changes the `get_aca_catalog` API to have separate kwargs for acq and guide. 

- The include/exclude functionality is implemented and working for acq catalog selection.
- For guide it is only a stub but there are minimal tests showing that it does set the appropriate `GuideCatalog` `include_ids` and `exclude_ids` attributes.