### PR TITLE
Lower limit of mag_err=0.3 for color=1.5 stars

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -897,8 +897,8 @@ class StarsTable(ACACatalogTable):
         # For color=1.5 stars set a lower limit of 0.3 on the catalog mag error.
         # This is based on analysis in ipynb/star_selection/star-mag-std-dev.ipynb
         # which shows that for color=1.5 stars the observed mag error is
-        # does not correlate well with mag_err below around 0.3 and so capping
-        # at 0.3 is a reasonable way to capture the uncertainty.
+        # does not correlate well with mag_err below around 0.3 and so setting a
+        # floor of 0.3 is a reasonable way to capture the uncertainty.
         ok = stars['COLOR1'] == 1.5
         mag_aca_err[ok] = mag_aca_err[ok].clip(0.3)
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -893,6 +893,15 @@ class StarsTable(ACACatalogTable):
         # the true star mag) and the sample uncertainty in the ACA readout mag
         # for a star with mag=MAG_ACA.  The latter typically dominates above 9th mag.
         mag_aca_err = stars['MAG_ACA_ERR'] * 0.01
+
+        # For color=1.5 stars set a lower limit of 0.3 on the catalog mag error.
+        # This is based on analysis in ipynb/star_selection/star-mag-std-dev.ipynb
+        # which shows that for color=1.5 stars the observed mag error is
+        # does not correlate well with mag_err below around 0.3 and so capping
+        # at 0.3 is a reasonable way to capture the uncertainty.
+        ok = stars['COLOR1'] == 1.5
+        mag_aca_err[ok] = mag_aca_err[ok].clip(0.3)
+
         mag_std_dev = get_mag_std(stars['MAG_ACA'])
         mag_err = np.sqrt(mag_aca_err ** 2 + mag_std_dev ** 2)
         stars.add_column(Column(mag_err, name='mag_err'), index=8)

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -199,3 +199,18 @@ def test_calc_spoiler_impact_21068():
     assert np.abs(dy) < 1.5
     assert np.abs(dz) < 1.5
     assert np.abs(f) > 0.95
+
+
+def test_mag_err_clip():
+    # Clipping case for star
+    s1 = StarsTable.from_agasc_ids(att=[6.88641501, 16.8899464, 0],
+                                   agasc_ids=[154667024])
+    # s1['MAG_ACA_ERR'] = 77 (0.77)
+    assert s1['COLOR1'] == 1.5
+    assert np.isclose(s1['mag_err'], 0.77, rtol=0, atol=0.01)
+
+    s1 = StarsTable.from_agasc_ids(att=[7.01214503, 17.8931235, 0],
+                                   agasc_ids=[155072616])
+    # s1['MAG_ACA_ERR'] = 9  (0.09)
+    assert s1['COLOR1'] == 1.5
+    assert np.isclose(s1['mag_err'], 0.3, rtol=0, atol=0.01)


### PR DESCRIPTION
For color=1.5 stars set a lower limit of 0.3 on the catalog mag error. This is based on analysis in ipynb/star_selection/star-mag-std-dev.ipynb which shows that for color=1.5 stars the observed mag error is does not correlate well with mag_err below around 0.3 (on the negative side) and so capping at 0.3 is a reasonable way to capture the uncertainty.

![image](https://user-images.githubusercontent.com/348089/49514587-b35c2500-f851-11e8-8341-65564ebcaa30.png)

