### PR TITLE
Tweak include/exclude args to be lists of ints as needed

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -2,6 +2,7 @@ import functools
 import pickle
 import inspect
 import time
+import collections
 from copy import copy
 from pathlib import Path
 
@@ -371,11 +372,23 @@ class ACACatalogTable(Table):
             self._default_formats[name] = '.6f'
 
     def set_attrs_from_kwargs(self, **kwargs):
+
+        # The include/exclude kwargs appear to need to be undefined or lists of ints
+        for name in ['include_ids_acq', 'include_halfws_acq', 'include_ids_guide',
+                    'exclude_ids_acq', 'exclude_ids_guide']:
+            if name in kwargs:
+                if not isinstance(kwargs[name], collections.Iterable):
+                    kwargs[name] = [int(kwargs[name])]
+                else:
+                    kwargs[name] = [int(i) for i in kwargs[name]]
+
+
         for name, val in kwargs.items():
             if name in self.allowed_kwargs:
                 setattr(self, name, val)
             else:
                 raise ValueError(f'unexpected keyword argument "{name}"')
+
 
         # If an explicit obsid is not provided to all getting parameters via mica
         # then all other params must be supplied.


### PR DESCRIPTION
Tweak include/exclude args to be lists of ints as needed

The include_*, exclude_* kwargs seems to end up as either empty numpy arrays, numpy arrays of floats, or single numpy ints when passed to Python from Matlab with pyexec.  I think none of those work in get_aca_catalog.  This PR is intended to cast all of them to lists of ints. 