### PR TITLE
Add IntListMetaAttribute for include/exclude attrs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,16 +51,16 @@ focus_offset  SIM focus offset [steps] (default=0)
 
 **Optional**
 
-=================== =========================================================
+=================== ===============================================================
 Argument            Description
-=================== =========================================================
-include_ids_acq     list of AGASC IDs of stars to include in acq catalog
-include_halfws_acq  list of acq halfwidths corresponding to ``include_ids``
-exclude_ids_acq     list of AGASC IDs of stars to exclude from acq catalog
-include_ids_guide   list of AGASC IDs of stars to include in guide catalog
-exclude_ids_guide   list of AGASC IDs of stars to exclude from guide catalog
+=================== ===============================================================
+include_ids_acq     int or list of AGASC IDs of stars to include in acq catalog
+include_halfws_acq  int or list of acq halfwidths corresponding to ``include_ids``
+exclude_ids_acq     int or list of AGASC IDs of stars to exclude from acq catalog
+include_ids_guide   int or list of AGASC IDs of stars to include in guide catalog
+exclude_ids_guide   int or list of AGASC IDs of stars to exclude from guide catalog
 stars               table of AGASC stars (will be fetched from agasc if None)
-=================== =========================================================
+=================== ===============================================================
 
 **Debug**
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -313,6 +313,11 @@ class IntMetaAttribute(MetaAttribute):
         instance.meta[self.name] = int(value)
 
 
+class IntListMetaAttribute(MetaAttribute):
+    def __set__(self, instance, value):
+        instance.meta[self.name] = np.atleast_1d(value).astype(np.int64).tolist()
+
+
 class ACACatalogTable(Table):
     """
     Base class for representing ACA catalogs in star selection.  This
@@ -349,11 +354,11 @@ class ACACatalogTable(Table):
     focus_offset = MetaAttribute()
     dark = MetaAttribute(pickle=False)
     stars = MetaAttribute(pickle=False)
-    include_ids_acq = MetaAttribute(default=[])
-    include_halfws_acq = MetaAttribute(default=[])
-    exclude_ids_acq = MetaAttribute(default=[])
-    include_ids_guide = MetaAttribute(default=[])
-    exclude_ids_guide = MetaAttribute(default=[])
+    include_ids_acq = IntListMetaAttribute(default=[])
+    include_halfws_acq = IntListMetaAttribute(default=[])
+    exclude_ids_acq = IntListMetaAttribute(default=[])
+    include_ids_guide = IntListMetaAttribute(default=[])
+    exclude_ids_guide = IntListMetaAttribute(default=[])
     optimize = MetaAttribute(default=True)
     verbose = MetaAttribute(default=False)
     print_log = MetaAttribute(default=False)

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -7,6 +7,8 @@ from astropy.io import ascii
 import agasc
 from ..core import (ACABox, get_kwargs_from_starcheck_text, calc_spoiler_impact,
                     StarsTable)
+from ..acq import AcqTable
+from ..guide import GuideTable
 
 
 def test_agasc_1p7():
@@ -214,3 +216,23 @@ def test_mag_err_clip():
     # s1['MAG_ACA_ERR'] = 9  (0.09)
     assert s1['COLOR1'] == 1.5
     assert np.isclose(s1['mag_err'], 0.3, rtol=0, atol=0.01)
+
+
+@pytest.mark.parametrize('cls', [AcqTable, GuideTable])
+@pytest.mark.parametrize('attr', ['include_ids', 'exclude_ids'])
+def test_alias_attributes(cls, attr):
+    """
+    Unit testing of descriptors, in particular the alias attributes
+    """
+    suffix = '_' + cls.__name__[:-5].lower()
+    for val, exp in ((2.2, [2]),
+                     (np.array([2.2, 3]), [2, 3])):
+        obj = cls()
+        setattr(obj, attr, val)
+        assert getattr(obj, attr) == exp
+        assert getattr(obj, attr + suffix) == exp
+
+        obj = cls()
+        setattr(obj, attr + suffix, val)
+        assert getattr(obj, attr) == exp
+        assert getattr(obj, attr + suffix) == exp


### PR DESCRIPTION
If possible let's go with this for 4.3.  Just need to add a test from get_aca_catalog but I expect it to work based on new unit tests.