### PR TITLE
Fix bug that was only using row dither for hot pixel region check

### DIFF
--- a/proseco/characteristics_guide.py
+++ b/proseco/characteristics_guide.py
@@ -9,6 +9,9 @@ fid_trap = {'row': -374,
 # Minimum scaled guide count for thumbs_up
 min_guide_count = 4.0
 
+# Add this padding to region checked for bad pixels (in addition to dither)
+dither_pix_pad = 0.4
+
 CCD = {'row_min': -512.0,
        'row_max': 512.0,
        'col_min': -512.0,

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -665,7 +665,9 @@ def get_imposter_mags(cand_stars, dark, dither):
                 idx = np.unravel_index(np.argmax(bin_image), bin_image.shape)
                 max_r = rminus + row_off + idx[0] * 2
                 max_c = cminus + col_off + idx[1] * 2
-        pixmax_mag = count_rate_to_mag(pixmax)
+        # Get the mag equivalent to pixmax.  If pixmax is zero (for a synthetic dark map)
+        # clip lower bound at 1.0 to avoid 'inf' mag and warnings from chandra_aca.transform
+        pixmax_mag = count_rate_to_mag(np.clip(pixmax, 1.0, None))
         pixmags.append(pixmax_mag)
         pix_r.append(max_r)
         pix_c.append(max_c)

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -612,8 +612,8 @@ def get_ax_range(n, extent):
     return a range for the row or col that is divisible by 2 and contains
     at least the requested extent.
 
-    :param n: row or col float value
-    :param extent: half of desired range from n
+    :param n: row or col float value (edge pixel coords)
+    :param extent: half of desired range from n (should include pixel dither)
     :returns: tuple of range as (minus, plus)
     """
     minus = int(np.floor(n - extent))

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -644,9 +644,9 @@ def get_imposter_mags(cand_stars, dark, dither):
     pix_r = []
     pix_c = []
 
-    # Define the 1/2 pixel region as half the 8x8 plus dither
-    row_extent = np.ceil(4 + dither.row)
-    col_extent = np.ceil(4 + dither.col)
+    # Define the 1/2 pixel region as half the 8x8 plus a pad plus dither
+    row_extent = 4 + GUIDE_CHAR.dither_pix_pad + dither.row
+    col_extent = 4 + GUIDE_CHAR.dither_pix_pad + dither.col
     for cand in cand_stars:
         rminus, rplus = get_ax_range(cand['row'], row_extent)
         cminus, cplus = get_ax_range(cand['col'], col_extent)

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -618,9 +618,7 @@ def get_ax_range(n, extent):
     """
     minus = int(np.floor(n - extent))
     plus = int(np.ceil(n + extent))
-    # Use this floor != ceil logic to skip doing anything if the float
-    # n is equivalent to an integer.  This only comes up in test/constructed cases
-    if (np.floor(n) != np.ceil(n)):
+    if (plus - minus) % 2 != 0:
         if n - np.floor(n) > 0.5:
             plus += 1
         else:

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -608,7 +608,8 @@ def check_column_spoilers(cand_stars, ok, stars, n_sigma):
 
 def get_ax_range(n, extent):
     """
-    Given a float pixel row or col value and an integer pixel "extent",
+    Given a float pixel row or col value and an "extent" in float pixels,
+    generally 4 + 1.6 for 8" dither and 4 + 5.0 for 20" dither,
     return a range for the row or col that is divisible by 2 and contains
     at least the requested extent.
 

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -606,22 +606,25 @@ def check_column_spoilers(cand_stars, ok, stars, n_sigma):
     return column_spoiled, rej
 
 
-def get_ax_range(n, extent):
+def get_ax_range(rc, extent):
     """
     Given a float pixel row or col value and an "extent" in float pixels,
     generally 4 + 1.6 for 8" dither and 4 + 5.0 for 20" dither,
     return a range for the row or col that is divisible by 2 and contains
     at least the requested extent.
 
-    :param n: row or col float value (edge pixel coords)
+    :param rc: row or col float value (edge pixel coords)
     :param extent: half of desired range from n (should include pixel dither)
     :returns: tuple of range as (minus, plus)
     """
-    minus = int(np.floor(n - extent))
-    plus = int(np.ceil(n + extent))
+    minus = int(np.floor(rc - extent))
+    plus = int(np.ceil(rc + extent))
+    # If there isn't an even range of pixels, add or subtract one from the range
     if (plus - minus) % 2 != 0:
-        if n - np.floor(n) > 0.5:
+        # If the "rc" value in on the 'right' side of a pixel, add one to the plus
+        if rc - np.floor(rc) > 0.5:
             plus += 1
+        # Otherwise subtract one from the minus
         else:
             minus -= 1
     return minus, plus

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -606,6 +606,25 @@ def check_column_spoilers(cand_stars, ok, stars, n_sigma):
     return column_spoiled, rej
 
 
+def get_ax_range(n, extent):
+    """
+    Given a float pixel row or col value and an integer pixel "extent",
+    return a range for the row or col that is divisible by 2 and contains
+    at least the requested extent
+    :param n: row or col float value
+    :param extent: half of desired range from n
+    :returns: tuple of range as (minus, plus)
+    """
+    minus = int(np.floor(n - extent))
+    plus = int(np.ceil(n + extent))
+    if (np.floor(n) != np.ceil(n)):
+        if n - np.floor(n) > .5:
+            plus += 1
+        else:
+            minus -= 1
+    return minus, plus
+
+
 def get_imposter_mags(cand_stars, dark, dither):
     """
     Get "pseudo-mag" of max pixel value in each candidate star region
@@ -615,18 +634,6 @@ def get_imposter_mags(cand_stars, dark, dither):
     :param dither: observation dither to be used to determine pixels a star could use
     :returns: np.array pixmags, np.array pix_r, np.array pix_c all of length cand_stars
     """
-    def get_ax_range(r, extent):
-
-        # Should come back to this and do something smarter
-        # but right now I just want things that bin nicely 2x2
-        rminus = int(np.floor(r - row_extent))
-        rplus = int(np.ceil(r + row_extent))
-        if (np.floor(r) != np.ceil(r)):
-            if r - np.floor(r) > .5:
-                rplus += 1
-            else:
-                rminus -= 1
-        return rminus, rplus
 
     pixmags = []
     pix_r = []
@@ -635,7 +642,7 @@ def get_imposter_mags(cand_stars, dark, dither):
     # Define the 1/2 pixel region as half the 8x8 plus dither
     row_extent = np.ceil(4 + dither.row)
     col_extent = np.ceil(4 + dither.col)
-    for idx, cand in enumerate(cand_stars):
+    for cand in cand_stars:
         rminus, rplus = get_ax_range(cand['row'], row_extent)
         cminus, cplus = get_ax_range(cand['col'], col_extent)
         pix = np.array(dark.aca[rminus:rplus, cminus:cplus])

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -610,15 +610,18 @@ def get_ax_range(n, extent):
     """
     Given a float pixel row or col value and an integer pixel "extent",
     return a range for the row or col that is divisible by 2 and contains
-    at least the requested extent
+    at least the requested extent.
+
     :param n: row or col float value
     :param extent: half of desired range from n
     :returns: tuple of range as (minus, plus)
     """
     minus = int(np.floor(n - extent))
     plus = int(np.ceil(n + extent))
+    # Use this floor != ceil logic to skip doing anything if the float
+    # n is equivalent to an integer.  This only comes up in test/constructed cases
     if (np.floor(n) != np.ceil(n)):
-        if n - np.floor(n) > .5:
+        if n - np.floor(n) > 0.5:
             plus += 1
         else:
             minus -= 1

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -288,6 +288,29 @@ def test_guides_include_exclude():
     assert np.allclose(guides['mag'], [10.0, 12.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6])
 
 
+def test_edge_star():
+    """
+    Add stars right at row and col max for 8" dither.
+    This test both confirms that the dark map extraction doesn't break and that
+    the stars can still be selected.
+    """
+    stars = StarsTable.empty()
+
+    stars.add_fake_constellation(mag=[7.0, 7.1, 7.2, 7.3],
+                                 id=[1, 2, 3, 4],
+                                 size=2000, n_stars=4)
+    # Add a stars exactly at col and row max for 8" dither
+    stars.add_fake_star(row=495.3, col=502.4, mag=6.0)
+    stars.add_fake_star(row=-495.3, col=502.4, mag=6.0)
+    stars.add_fake_star(row=-495.3, col=-502.4, mag=6.0)
+    stars.add_fake_star(row=495.3, col=-502.4, mag=6.0)
+
+    std_info = STD_INFO.copy()
+    std_info.update(n_guide=8)
+    guides = get_guide_catalog(**std_info, stars=stars)
+    assert len(guides) == 8
+
+
 def test_get_ax_range():
     # Confirm that the ranges from get_ax_range are reasonable for a variety of
     # center pixel locations and extents (extent = 4 + pix_dither)

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -11,7 +11,7 @@ from chandra_aca.aca_image import ACAImage, AcaPsfLibrary
 from chandra_aca.transform import mag_to_count_rate, count_rate_to_mag
 
 from ..guide import (get_guide_catalog, check_spoil_contrib, get_pixmag_for_offset,
-                     check_mag_spoilers)
+                     check_mag_spoilers, get_ax_range)
 from ..characteristics_guide import mag_spoiler
 from ..core import StarsTable
 from .test_common import STD_INFO
@@ -286,3 +286,22 @@ def test_guides_include_exclude():
 
     assert np.all(guides['id'] == [9, 11, 2, 3, 4, 5, 6, 7])
     assert np.allclose(guides['mag'], [10.0, 12.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6])
+
+
+def test_get_ax_range():
+    # Confirm that the ranges from get_ax_range are reasonable for a variety of
+    # center pixel locations and extents (extent = 4 + pix_dither)
+    ns = [0, 0.71, 495.3, -200.2]
+    extents = [4.0, 5.6, 4.8, 9.0]
+    for (n, extent) in itertools.product(ns, extents):
+        minus, plus = get_ax_range(n, extent)
+        # Confirm range divisable by 2
+        assert (plus - minus) % 2 == 0
+        # Confirm return order
+        assert plus > minus
+        # Confirm the range contains the full extent
+        assert n + extent <= plus
+        assert n - extent >= minus
+        # Confirm the range does not contain more than 2 pix extra on either side
+        assert n + extent + 2 > plus
+        assert n - extent - 2 < minus

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -349,8 +349,10 @@ def test_edge_star(dither):
 
 
 def test_get_ax_range():
-    # Confirm that the ranges from get_ax_range are reasonable for a variety of
-    # center pixel locations and extents (extent = 4 + pix_dither)
+    """
+    Confirm that the ranges from get_ax_range are reasonable for a variety of
+    center pixel locations and extents (extent = 4 + pix_dither)
+    """
     ns = [0, 0.71, 495.3, -200.2]
     extents = [4.0, 5.6, 4.8, 9.0]
     for (n, extent) in itertools.product(ns, extents):


### PR DESCRIPTION
Fix bug that was only using row dither for hot pixel region check

`get_ax_range` was ignoring the supplied value of "extent" and using row_extent always.  This is an issue for observations with asymmetric dither.

`get_ax_range` is still ugly, but I've moved it to top level so I can use it equivalently from the guide reporting.

Closes #194 