### PR TITLE
Updates to support validating proseco pickle contents

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -1145,7 +1145,7 @@ def pea_reject_image(img):
     return False
 
 
-def get_kwargs_from_starcheck_text(obs_text):
+def get_kwargs_from_starcheck_text(obs_text, include_cat=False):
     """
     Get proseco kwargs using the exact catalog from the starcheck output text
     ``obs_text``.  Mostly copied from annie/annie (should move into mica.starcheck
@@ -1215,6 +1215,8 @@ def get_kwargs_from_starcheck_text(obs_text):
         fid_or_mon = (cat['type'] == 'FID') | (cat['type'] == 'MON')
         kw['n_guide'] = 8 - np.count_nonzero(fid_or_mon)
         kw['n_fid'] = np.count_nonzero(cat['type'] == 'FID')
+        if include_cat:
+            kw['cat'] = cat
     except:
         pass
 

--- a/validate/starcheck_proseco.py
+++ b/validate/starcheck_proseco.py
@@ -227,13 +227,4 @@ def get_starcheck_proseco_outputs(load_name, out_root='.'):
         proseco_cats[int(str_obsid)] = proseco_cat
         del proseco_cats[str_obsid]
 
-    proseco_cats_obsids = set(proseco_cats)
-    starcheck_obss_obsids = set(starcheck_obss)
-    if proseco_cats_obsids > starcheck_obss_obsids:
-        print(f'Obsids {proseco_cats_obsids - starcheck_obss_obsids}'
-              f' in proseco but not in backstop')
-    if proseco_cats_obsids < starcheck_obss_obsids:
-        print(f'Obsids {starcheck_obss_obsids - proseco_cats_obsids}'
-              f' in backstop but not in proseco')
-
     return proseco_cats, starcheck_obss

--- a/validate/starcheck_proseco.py
+++ b/validate/starcheck_proseco.py
@@ -37,6 +37,7 @@ or remove:
 - starcheck.txt : to re-do starcheck
 """
 
+import pickle
 from pathlib import Path
 import subprocess
 import shutil
@@ -143,7 +144,8 @@ def get_starcheck_obs_kwargs(filename):
         if "No star catalog for obsid" in chunk:
             continue
         try:
-            out = get_kwargs_from_starcheck_text(chunk)
+            out = get_kwargs_from_starcheck_text(chunk, include_cat=True)
+
         except ValueError:
             continue
         else:
@@ -196,3 +198,42 @@ def run_starcheck(load_name, out_root):
     print(f'Running starcheck in {load_dir}')
     with Ska.File.chdir(str(load_dir)):
         subprocess.run(['bash', '/proj/sot/ska/bin/starcheck'])
+
+
+def get_starcheck_proseco_outputs(load_name, out_root='.'):
+    """Get the complete set of output proseco pickles for each obsid and the corresponding
+    set of observations parameters and backstop catalogs by parsing starcheck.txt.
+
+    :param load_name: load name e.g. 'AUG2018T'
+    :param out_root: directory containing the <load_name> directory (default='.')
+
+    :returns: proseco_cats, starcheck_obss: dicts by obsid
+    """
+    load_dir = Path(out_root, load_name)
+    starcheck_txt = load_dir / 'starcheck.txt'
+    proseco_pickle = load_dir / f'{load_name}_proseco.pkl'
+
+    # First get all the expected calling arguments for all obsids in starcheck output.
+    # This returns a list of dict with get_aca_catalog calling args.  This also returns
+    # the catalog as a Table in the 'cat' key.
+    starcheck_obss = get_starcheck_obs_kwargs(starcheck_txt)
+
+    # Now load the load products pickle with all catalogs
+    proseco_cats = pickle.load(open(proseco_pickle, 'rb'))
+
+    # Change obsid key from str to int (that's the way MATLAB stores them).
+    for str_obsid in list(proseco_cats):
+        proseco_cat = proseco_cats[str_obsid]
+        proseco_cats[int(str_obsid)] = proseco_cat
+        del proseco_cats[str_obsid]
+
+    proseco_cats_obsids = set(proseco_cats)
+    starcheck_obss_obsids = set(starcheck_obss)
+    if proseco_cats_obsids > starcheck_obss_obsids:
+        print(f'Obsids {proseco_cats_obsids - starcheck_obss_obsids}'
+              f' in proseco but not in backstop')
+    if proseco_cats_obsids < starcheck_obss_obsids:
+        print(f'Obsids {starcheck_obss_obsids - proseco_cats_obsids}'
+              f' in backstop but not in proseco')
+
+    return proseco_cats, starcheck_obss


### PR DESCRIPTION
This goes along with validate-pickle-contents.ipynb in the usual place.