### PR TITLE
Refactor cat table

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -127,6 +127,10 @@ class AcqTable(ACACatalogTable):
     _fid_set = MetaAttribute(is_kwarg=False, default=())
     imposters_mag_limit = MetaAttribute(is_kwarg=False, default=20.0)
 
+    def __init__(self, data=None, **kwargs):
+        super().__init__(data, **kwargs)
+        self._default_formats['p_acq'] = '.3f'
+
     @classmethod
     def empty(cls):
         """

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -939,6 +939,9 @@ class StarsTable(BaseCatalogTable):
         Return a StarsTable from an existing AGASC stars query.  This just updates
         columns in place.
 
+        If ``stars`` is a StarsTable, the attitude of that object ``stars.att`` must
+        match ``att`` to within 0.001 arcsec in pitch, yaw, and roll.
+
         :param att: any Quat-compatible attitude
         :param stars: Table of stars
         :param logger: logger object (default=None)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -864,6 +864,18 @@ class StarsTable(BaseCatalogTable):
                 pass
             return null_logger
 
+    def plot(self, ax=None):
+        """
+        Plot the star field.
+
+        :param ax: matplotlib axes object for plotting to (optional)
+        """
+        from chandra_aca.plot import plot_stars
+        import matplotlib.pyplot as plt
+
+        plot_stars(attitude=self.att, stars=self, ax=ax)
+        plt.show()
+
     @classmethod
     def from_agasc(cls, att, date=None, radius=1.2, logger=None):
         """

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -282,6 +282,12 @@ def test_aca_acq_gui_thumbs_up(config):
 
 
 def test_fid_trap_effect():
+    """Test that guide stars impacted by fid trap effect are excluded.
+
+    This uses two flight obsids that showed this issue.  See:
+    http://cxc.cfa.harvard.edu/mta/ASPECT/aca_weird_pixels/
+
+    """
     # Obsid 1576
     agasc_ids = [367148872, 367139768, 367144424, 367674552, 367657896]
     att = [10.659376, 40.980028, 181.012903]
@@ -290,10 +296,15 @@ def test_fid_trap_effect():
     assert 367674552 not in cat.guides['id']
 
     # Obsid 2365
+    # NOTE: the att below is in fact the actual 2365 attitude, which differs
+    # from what mica.starcheck reports as [243.598372, -63.123245, 123.674233].
+    # See: https://github.com/sot/mica/issues/184
     agasc_ids = [1184926344, 1184902704, 1184897704, 1184905208, 1185050656]
     att = [243.552030, -63.091108, 224.513314]
     stars = StarsTable.from_agasc_ids(att, agasc_ids)
-    cat = get_aca_catalog(obsid=2365, stars=stars, raise_exc=True)
+
+    # Specify att kwarg explicitly to override what is found in mica.starcheck
+    cat = get_aca_catalog(obsid=2365, stars=stars, raise_exc=True, att=att)
     assert 1184897704 not in cat.guides['id']
 
 

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -236,3 +236,25 @@ def test_alias_attributes(cls, attr):
         setattr(obj, attr + suffix, val)
         assert getattr(obj, attr) == exp
         assert getattr(obj, attr + suffix) == exp
+
+
+def test_starstable_from_stars():
+    """Test initializing a StarsTable from stars where att can be different.
+
+    Tests with an attitude is 0.0005 arsec different (OK) and 0.002 arcsec
+    different (not OK).
+
+    """
+
+    dang = 0.001 / 3600  # limit
+    att = [0, 1, 359]
+    att2 = [0, 1 + dang * 2, 359 - 0.0005 / 2 ]
+    att3 = [0, 1 - dang / 2, 359 - dang / 2]
+    stars = StarsTable.from_agasc(att=att)
+
+    with pytest.raises(ValueError) as err:
+        StarsTable.from_stars(att2, stars)
+    assert 'supplied att' in str(err)
+
+    stars3 = StarsTable.from_stars(att3, stars)
+    assert stars3 is stars


### PR DESCRIPTION
Nothing really controversial here, just got annoyed that `StarsTable` was inherited from `ACACatalogTable` and got all these methods and such that really don't apply.

There is a small functional diff in that `StarsTable` now has its own `att` attribute that actually gets set and used.  This makes it possible to have a `plot()` method which I have added here.  It also makes it possible to check the attitude in `from_stars()`, and this led to the digression of obsid 2365 since that failed the attitude check originally.