### PR TITLE
Improve stars handling and put FOV filtering into set_stars()

### DIFF
--- a/proseco/characteristics.py
+++ b/proseco/characteristics.py
@@ -2,6 +2,7 @@ CCD = {'row_min': -512.0,
        'row_max': 512.0,
        'col_min': -512.0,
        'col_max': 512.0,
+       'fov_pad': 40.0,  # Padding *outside* CCD (filtering AGASC stars in/near FOV in set_stars)
        'window_pad': 7,
        'row_pad': 8,
        'col_pad': 1,
@@ -10,8 +11,9 @@ CCD = {'row_min': -512.0,
 PIX_2_ARC = 4.96289
 ARC_2_PIX = 1.0 / PIX_2_ARC
 
-max_ccd_row = 512 - 8  # Max allowed row for stars (SOURCE?)
-max_ccd_col = 512 - 1  # Max allow col for stars (SOURCE?)
+# Convenience characteristics
+max_ccd_row = CCD['row_max'] - CCD['row_pad']  # Max allowed row for stars (SOURCE?)
+max_ccd_col = CCD['col_max'] - CCD['col_pad']  # Max allow col for stars (SOURCE?)
 
 # Column spoiler rules
 col_spoiler_mag_diff = 4.5

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -24,6 +24,7 @@ def test_get_aca_catalog_49531():
     Test of getting an ER using the mica.starcheck archive for getting the
     obs parameters.  This tests a regression introduced in the acq-fid
     functionality.
+
     """
     aca = get_aca_catalog(49531, raise_exc=True)
     assert len(aca.acqs) == 8
@@ -64,6 +65,9 @@ def test_get_aca_catalog_20259():
     """
     Test obsid 20259 which has two spoiled fids: HRC-2 is yellow and HRC-4 is red.
     Expectation is to choose fids 1, 2, 3 (not 4).
+
+    Also do a test that set_stars() processing is behaving as expected.
+
     """
     aca = get_aca_catalog(20259, raise_exc=True)
     exp = ['slot idx     id    type  sz   yang     zang   dim res halfw',
@@ -82,6 +86,12 @@ def test_get_aca_catalog_20259():
 
     repr(aca)  # Apply default formats
     assert aca[TEST_COLS].pformat(max_width=-1) == exp
+
+    # Check that acqs, guides, and fids are sharing the same stars table
+    # but that it is different from the larger aca stars table.
+    assert aca.stars is not aca.acqs.stars
+    assert aca.fids.stars is aca.acqs.stars
+    assert aca.guides.stars is aca.acqs.stars
 
 
 def test_exception_handling():


### PR DESCRIPTION
The driver here is having the full list of stars (via radial selection from AGASC) available to allow roll optimization.  Now the `ACATable` catalog has the full list and acqs, fids, and guides have the FOV-filtered list (where FOV means within 40 pixels of the CCD edge).

The key code change is moving the FOV-filtering from `StarsTable.from_stars()` into `ACACatalogTable.set_stars()`, and adding a new arg to the latter to turn-off FOV-filtering if required.