### PR TITLE
Fix a regression on p_acq formatting

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -127,10 +127,6 @@ class AcqTable(ACACatalogTable):
     _fid_set = MetaAttribute(is_kwarg=False, default=())
     imposters_mag_limit = MetaAttribute(is_kwarg=False, default=20.0)
 
-    def __init__(self, data=None, **kwargs):
-        super().__init__(data, **kwargs)
-        self._default_formats['p_acq'] = '.3f'
-
     @classmethod
     def empty(cls):
         """

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -353,6 +353,7 @@ class BaseCatalogTable(Table):
         # Make printed table look nicer.  This is defined in advance
         # and will be applied the first time the table is represented.
         self._default_formats = {}
+        self._default_formats['p_acq'] = '.3f'
         for name in ('yang', 'zang', 'row', 'col', 'mag', 'maxmag', 'mag_err', 'color', 'COLOR1'):
             self._default_formats[name] = '.2f'
         for name in ('ra', 'dec', 'RA_PMCORR', 'DEC_PMCORR'):


### PR DESCRIPTION
Commit a49ac511 accidentally removed the format specification for `p_acq` in `ACATable`.  This puts it back.