### PR TITLE
WIP: optimize roll

### DIFF
--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -507,3 +507,50 @@ def merge_cats(fids=None, guides=None, acqs=None):
     aca.add_column(idx, index=1)
 
     return aca
+
+ROLL_TABLE = Table.read("""
+pitch   rolldev
+46      0
+46.2    1.269
+46.4    2.052
+46.6    2.635
+46.8    3.111
+47      3.517
+47.2    3.942
+47.5    4.501
+48      5.192
+48.5    5.771
+49      6.268
+49.5    6.726
+50      7.142
+55      10.043
+60      11.753
+65      12.894
+70      13.659
+75      14.182
+80      14.523
+85      19.899
+137.08  7.334
+140     7.775
+145     8.697
+150     9.979
+153     11.021
+157     12.785
+160     14.628
+163     17.153
+166     19.999
+170     19.999
+180     19.999""", format='ascii')
+
+
+def allowed_rolldev(pitch):
+    """Get allowed roll deviation (off-nominal roll) for the given ``pitch``.
+
+    This uses the OFLS table and is an approximation to the true planning limit.
+    This is basically the same as https://github.com/sot/Ska.Sun/pull/5.
+
+    :param pitch: Sun pitch angle (deg)
+    :returns: Roll deviation (deg)
+    """
+    idx = np.searchsorted(ROLL_TABLE['pitch'], pitch, side='right')
+    return ROLL_TABLE['rolldev'][idx - 1]

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -453,14 +453,14 @@ class ACATable(ACACatalogTable):
             if ids not in uniq_ids_sets and ids - ids0:
                 uniq_ids_sets.append(ids)
 
-        print(f'Roll min, max={roll_min:.2f}, {roll_max:.2f}')
+        # print(f'Roll min, max={roll_min:.2f}, {roll_max:.2f}')
         # For each unique set, find the roll_offset range over which that set
         # is in the FOV.
         better_rolls = []
         for uniq_ids in uniq_ids_sets:
             # print(uniq_ids - ids0, ids0 - uniq_ids)
-            for sid in uniq_ids - ids0:
-                star = self.stars.get_id(sid)
+            # for sid in uniq_ids - ids0:
+                # star = self.stars.get_id(sid)
                 # print(f'{sid} {star["mag"]} {star["yang"]} {star["zang"]}')
             # This says that ``uniq_ids`` is a subset of available ``ids`` in
             # FOV for roll_offset.
@@ -477,7 +477,7 @@ class ACATable(ACACatalogTable):
                 better_roll = (interval['x_start'] + interval['x_stop']) / 2
                 better_rolls.append(np.clip(better_roll, roll_min, roll_max))
 
-        return sorted(set(better_rolls))
+        return sorted(set(better_rolls)), roll_min, roll_nom, roll_max
 
 
 def merge_cats(fids=None, guides=None, acqs=None):

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -356,7 +356,7 @@ class ACATable(ACACatalogTable):
         # Find potential acq stars that are noticably better than worst acq
         # star via the p_acq_model metric, defined as p_acq is at least 0.3
         # better.
-        acq_ok = self.acqs.get_candidates_filter(stars)
+        acq_ok = self.acqs.get_candidates_mask(stars)
         idxs = np.flatnonzero(sp_ok & acq_ok)
         p_acqs = acq_success_prob(date=self.acqs.date, t_ccd=self.acqs.t_ccd,
                                   mag=stars['mag'][idxs], color=stars['COLOR1'][idxs],
@@ -367,7 +367,7 @@ class ACATable(ACACatalogTable):
 
         # Find potential guide stars that are noticably better than worst guide
         # star, defined as being at least 0.2 mag brighter.
-        guide_ok = self.guides.get_candidates_filter(stars)
+        guide_ok = self.guides.get_candidates_mask(stars)
         idxs = np.flatnonzero(sp_ok & guide_ok)
         worst_mag = np.max(self.guides['mag'])
         ok = stars['mag'][idxs] < worst_mag - 0.2
@@ -453,15 +453,15 @@ class ACATable(ACACatalogTable):
             if ids not in uniq_ids_sets and ids - ids0:
                 uniq_ids_sets.append(ids)
 
-        print(roll_min, roll_max)
+        print(f'Roll min, max={roll_min:.2f}, {roll_max:.2f}')
         # For each unique set, find the roll_offset range over which that set
         # is in the FOV.
         better_rolls = []
         for uniq_ids in uniq_ids_sets:
-            print(uniq_ids - ids0, ids0 - uniq_ids)
+            # print(uniq_ids - ids0, ids0 - uniq_ids)
             for sid in uniq_ids - ids0:
                 star = self.stars.get_id(sid)
-                print(f'{sid} {star["mag"]} {star["yang"]} {star["zang"]}')
+                # print(f'{sid} {star["mag"]} {star["yang"]} {star["zang"]}')
             # This says that ``uniq_ids`` is a subset of available ``ids`` in
             # FOV for roll_offset.
             in_fov = np.array([uniq_ids <= ids for ids in ids_list])
@@ -470,9 +470,9 @@ class ACATable(ACACatalogTable):
             intervals = logical_intervals(in_fov, x=roll_offsets + roll)
 
             for interval in intervals:
-                print(interval)
+                # print(interval)
                 if interval['x_start'] > roll_max or interval['x_stop'] < roll_min:
-                    print(f'skipping {roll_max} {roll_min}')
+                    # print(f'skipping {roll_max} {roll_min}')
                     continue  # Interval completely outside allowed roll range
                 better_roll = (interval['x_start'] + interval['x_stop']) / 2
                 better_rolls.append(np.clip(better_roll, roll_min, roll_max))

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -1405,3 +1405,42 @@ def get_kwargs_from_starcheck_text(obs_text, include_cat=False, force_catalog=Fa
         pass
 
     return kw
+
+
+def logical_intervals(vals, x=None):
+    """
+    Determine contiguous intervals during which ``vals`` is True.
+
+    Returns an Astropy Table with a row for each interval.  Columns are:
+
+    * idx_start: index of interval start
+    * idx_stop: index of interval stop
+    * x_start: x value at idx_start (if ``x`` is supplied)
+    * x_stop: x value at idx_stop (if ``x`` is supplied)
+
+    :param vals: bool values for which intervals are returned.
+    :param x: x-axis values corresponding to ``vals``
+    :returns: Table of intervals
+
+    """
+    if len(vals) < 2:
+        raise ValueError('Filtered data length must be at least 2')
+
+    transitions = np.concatenate([[True], vals[:-1] != vals[1:], [True]])
+
+    state_vals = vals[transitions[1:]]
+    state_idxs = np.where(transitions)[0]
+
+    intervals = {'idx_start': state_idxs[:-1],
+                 'idx_stop': state_idxs[1:] - 1}
+
+    out = Table(intervals, names=sorted(intervals))
+
+    # Filter only the True states
+    out = out[state_vals]
+
+    if x is not None:
+        out['x_start'] = x[out['idx_start']]
+        out['x_stop'] = x[out['idx_stop']]
+
+    return out


### PR DESCRIPTION
This has rough draft code for:
- Identify candidate acq and guide stars at different rolls that might improve the catalogs
- Identify discrete roll ranges where those stars are in the FOV

Currently it is more focused on acquisition.  The tricky bit as always is weighing guide vs acq goodness.

Testing with:
```
import numpy as np
from proseco import get_aca_catalog
from chandra_aca.star_probs import guide_count

aca = get_aca_catalog(18925)
cands = aca.get_better_roll_candidates()
ids_list, ids0 = aca.find_roll_ranges(cands, d_roll=0.25)

ids_list.append(({}, {}, [0, 0]))

acas = []
for d1, d2, roll_offsets in ids_list:
    for roll_offset in (roll_offsets[0], np.mean(roll_offsets), roll_offsets[1]):
        aca_roll = get_aca_catalog(18925, att=[aca.att[0], aca.att[1], aca.att[2] + roll_offset],
                                   dark=aca.dark, raise_exc=True)
        print(f'************* roll_offset = {roll_offset} **************')
        print(f'P2 = {-np.log10(aca_roll.acqs.calc_p_safe()):.2f}')
        n_stars = guide_count(aca_roll.guides['mag'], aca_roll.t_ccd)
        print(f'n_stars = {n_stars:.2f}')
        acas.append(aca_roll)
```
This finds a much better catalog at a roll offset of -19 deg, though sadly that is not legal for this observation.  But it finds a somewhat better catalog in the allowed range.