### PR TITLE
Make plot() method behave consistently and correctly

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -72,7 +72,7 @@ def get_acq_catalog(obsid=0, **kwargs):
     acqs.p_man_errs = np.array([get_p_man_err(man_err, acqs.man_angle)
                                 for man_err in ACQ.man_errs])
 
-    acqs.cand_acqs, acqs.bad_stars = acqs.get_acq_candidates(acqs.stars)
+    acqs.cand_acqs = acqs.get_acq_candidates(acqs.stars)
 
     # Fill in the entire acq['probs'].p_acqs table (which is actual a dict of keyed by
     # (box_size, man_err) tuples).
@@ -110,6 +110,9 @@ class AcqTable(ACACatalogTable):
     """
     Catalog of acquisition stars
     """
+    # Catalog type when plotting (None | 'FID' | 'ACQ' | 'GUI')
+    catalog_type = 'ACQ'
+
     # Elements of meta that should not be directly serialized to pickle
     # (either too big or requires special handling).
     pickle_exclude = ('stars', 'dark', 'bad_stars')
@@ -258,8 +261,7 @@ class AcqTable(ACACatalogTable):
                 'detector', 'sim_offset', 'focus_offset')
         return {key: getattr(self, key) for key in keys}
 
-    @staticmethod
-    def get_candidates_filter(stars):
+    def get_candidates_mask(self, stars):
         """Get base filter for acceptable candidates.
 
         This does not include spatial filtering.
@@ -292,12 +294,11 @@ class AcqTable(ACACatalogTable):
 
         :returns: Table of candidates, indices of rejected stars
         """
-        ok = (self.get_candidates_filter(stars) &
+        ok = (self.get_candidates_mask(stars) &
               (np.abs(stars['row']) < ACA.max_ccd_row) &  # Max usable row
               (np.abs(stars['col']) < ACA.max_ccd_col)  # Max usable col
               )
 
-        bads = ~ok
         cand_acqs = stars[ok]
 
         cand_acqs.sort('mag')
@@ -357,7 +358,7 @@ class AcqTable(ACACatalogTable):
         cand_acqs['imposters_box'] = np.full(n_cand, None)
         cand_acqs['box_sizes'] = box_sizes_list
 
-        return cand_acqs, bads
+        return cand_acqs
 
     def get_box_sizes(self, cand_acqs):
         """Get the available box sizes for each cand_acq as all those with size <= the

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -409,6 +409,9 @@ class AcqTable(ACACatalogTable):
         """
         if acq['id'] in ACA.bad_star_set:
             self.log(f'Rejecting star {acq["id"]} which is in bad star list', id=acq['id'])
+            idx = self.stars.get_id_idx(acq['id'])
+            self.bad_stars_mask[idx] = True
+
             return True
         else:
             return False

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -139,6 +139,10 @@ def _get_aca_catalog(**kwargs):
 
 
 class ACATable(ACACatalogTable):
+    """Container ACACatalogTable class that has merged guide / acq / fid catalogs
+    as attributes and other methods relevant to the merged catalog.
+
+    """
     optimize = MetaAttribute(default=True)
     call_args = MetaAttribute(default={})
 
@@ -159,6 +163,22 @@ class ACATable(ACACatalogTable):
         return int(self.acqs.thumbs_up &
                    self.fids.thumbs_up &
                    self.guides.thumbs_up)
+
+    def get_candidates_mask(self, stars):
+        """Return a boolean mask indicating which ``stars`` are acceptable candidates
+        for the parent class.
+
+        For ACATable this is the logical OR of the guide and acq values,
+        i.e. for ACA a candidate is shown as OK if it is OK for either guide or
+        acq.  This is just used for plotting.
+
+        :param stars: StarsTable of stars
+        :returns: bool mask
+
+        """
+        ok = (self.acqs.get_candidates_mask(stars) |
+              self.guides.get_candidates_mask(stars))
+        return ok
 
     def make_report(self, rootdir='.'):
         """

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -425,7 +425,7 @@ class BaseCatalogTable(Table):
         arg of plot_stars where bad stars are plotting in a distinctive color.
 
         """
-        if not hasattr(self, '_bad_stars'):
+        if not hasattr(self, '_bad_stars_mask'):
             self._bad_stars_mask = ~self.get_candidates_mask(self.stars)
         return self._bad_stars_mask
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -347,6 +347,9 @@ class BaseCatalogTable(Table):
     - Indexing on 'id' column
 
     """
+    # Catalog type when plotting (None | 'FID' | 'ACQ' | 'GUI')
+    catalog_type = None
+
     def __init__(self, data=None, **kwargs):
         super().__init__(data=data, **kwargs)
 
@@ -397,6 +400,62 @@ class BaseCatalogTable(Table):
                 raise KeyError(f'{id} is not in table')
 
         return idx
+
+    def get_candidates_mask(self, stars):
+        """Return a boolean mask indicating which ``stars`` are acceptable candidates
+        for the parent class.  This basically applies to guide and acq, though
+        ACACatalog uses a hybrid of those two.
+
+        This is used directly in selection of candidates.  For the base class all
+        stars are considered acceptable.
+
+        :param stars: StarsTable of stars
+        :returns: bool mask
+
+        """
+        return np.ones(len(stars), dtype=bool)
+
+    @property
+    def bad_stars_mask(self):
+        """Mask of stars that are not acceptable candidates for the parent class.  This
+        basically applies to guide and acq, though ACACatalog uses a hybrid of
+        those two.
+
+        This is mostly used for plotting, corresponding to the ``bad_stars``
+        arg of plot_stars where bad stars are plotting in a distinctive color.
+
+        """
+        if not hasattr(self, '_bad_stars'):
+            self._bad_stars_mask = ~self.get_candidates_mask(self.stars)
+        return self._bad_stars_mask
+
+    @bad_stars_mask.setter
+    def bad_stars_mask(self, value):
+        self._bad_stars_mask = value
+
+    @property
+    def bad_stars(self):
+        """Back-compatibility property for bad_stars_mask"""
+        return self.bad_stars_mask
+
+    def plot(self, ax=None, **kwargs):
+        """
+        Plot the catalog and background stars.
+
+        :param ax: matplotlib axes object for plotting to (optional)
+        :param kwargs: other keyword args for plot_stars
+        """
+        from chandra_aca.plot import plot_stars
+        import matplotlib.pyplot as plt
+
+        kwargs.setdefault('stars', np.array([]))
+
+        # Explicitly set bad_stars so that plot_stars does not apply its
+        # internal version (which is no lot always the right answer).
+        kwargs.setdefault('bad_stars', np.zeros(len(kwargs['stars']), dtype=bool))
+
+        plot_stars(attitude=self.att, ax=ax, **kwargs)
+        plt.show()
 
 
 class ACACatalogTable(BaseCatalogTable):
@@ -558,22 +617,29 @@ class ACACatalogTable(BaseCatalogTable):
 
         self.stars = stars
 
-    def plot(self, ax=None):
+    def get_catalog_for_plot(self):
+        """Return value of ``catalog`` for plot_stars() call for this object
+
+        For ACACatalogTable this is the self Table object but with the possibility
+        of changing all the `type` column values to self.catalog_type (e.g. 'ACQ').
+
+        """
+        catalog = self.as_array()
+        if self.catalog_type:
+            catalog['type'] = self.catalog_type
+        return catalog
+
+    def plot(self, ax=None, **kwargs):
         """
         Plot the catalog and background stars.
 
         :param ax: matplotlib axes object for plotting to (optional)
+        :param kwargs: other keyword args for plot_stars
         """
-        from chandra_aca.plot import plot_stars
-        import matplotlib.pyplot as plt
-
-        stars_kwargs = {}
-        if self.acqs:
-            stars_kwargs['stars'] = self.acqs.stars
-            stars_kwargs['bad_stars'] = self.acqs.bad_stars
-
-        plot_stars(attitude=self.att, catalog=self, ax=ax, **stars_kwargs)
-        plt.show()
+        kwargs.setdefault('catalog', self.get_catalog_for_plot())
+        kwargs.setdefault('stars', self.stars)
+        kwargs.setdefault('bad_stars', self.bad_stars_mask)
+        super().plot(ax, **kwargs)
 
     @property
     def dither(self):
@@ -879,17 +945,22 @@ class StarsTable(BaseCatalogTable):
                 pass
             return null_logger
 
-    def plot(self, ax=None):
+    def get_catalog_for_plot(self):
+        """Return value of ``catalog`` for plot_stars() call for this object
+
+        For StarsTable this is None (no catalog).
+        """
+        return None
+
+    def plot(self, ax=None, **kwargs):
         """
         Plot the star field.
 
         :param ax: matplotlib axes object for plotting to (optional)
+        :param kwargs: other keywords for plot_stars
         """
-        from chandra_aca.plot import plot_stars
-        import matplotlib.pyplot as plt
-
-        plot_stars(attitude=self.att, stars=self, ax=ax)
-        plt.show()
+        kwargs.setdefault('stars', self)
+        super().plot(ax, **kwargs)
 
     @classmethod
     def from_agasc(cls, att, date=None, radius=1.2, logger=None):

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -74,6 +74,9 @@ def get_fid_catalog(obsid=0, **kwargs):
 
 
 class FidTable(ACACatalogTable):
+    # Catalog type when plotting (None | 'FID' | 'ACQ' | 'GUI')
+    catalog_type = 'FID'
+
     # Name of table.  Use to define default file names where applicable.
     # (e.g. `obs19387/fids.pkl`).
     name = 'fids'

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -64,6 +64,8 @@ def get_guide_catalog(obsid=0, **kwargs):
 
 
 class GuideTable(ACACatalogTable):
+    # Catalog type when plotting (None | 'FID' | 'ACQ' | 'GUI')
+    catalog_type = 'GUI'
 
     # Elements of meta that should not be directly serialized to pickle.
     # (either too big or requires special handling).
@@ -288,8 +290,7 @@ class GuideTable(ACACatalogTable):
 
         super().process_include_ids(cand_guides, stars[ok])
 
-    @staticmethod
-    def get_candidates_filter(stars):
+    def get_candidates_mask(self, stars):
         """Get base filter for acceptable candidates.
 
         This does not include spatial filtering.
@@ -318,7 +319,7 @@ class GuideTable(ACACatalogTable):
 
         # Use the primary selection filter from acq, but allow bad color
         # and limit to brighter stars
-        ok = (self.get_candidates_filter(stars) &
+        ok = (self.get_candidates_mask(stars) &
               (np.abs(stars['row']) < ACA.max_ccd_row) &  # Max usable row
               (np.abs(stars['col']) < ACA.max_ccd_col)  # Max usable col
               )

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -288,6 +288,27 @@ class GuideTable(ACACatalogTable):
 
         super().process_include_ids(cand_guides, stars[ok])
 
+    @staticmethod
+    def get_candidates_filter(stars):
+        """Get base filter for acceptable candidates.
+
+        This does not include spatial filtering.
+
+        :param stars: StarsTable
+        :returns: bool mask of acceptable stars
+
+        """
+        ok = ((stars['CLASS'] == 0) &
+              (stars['mag'] > 5.9) &
+              (stars['mag'] < 10.3) &
+              (stars['mag_err'] < 1.0) &  # Mag err < 1.0 mag
+              (stars['ASPQ1'] < 20) &  # Less than 1 arcsec offset from nearby spoiler
+              (stars['ASPQ2'] == 0) &  # Proper motion less than 0.5 arcsec/yr
+              (stars['POS_ERR'] < 3000) &  # Position error < 3.0 arcsec
+              ((stars['VAR'] == -9999) | (stars['VAR'] == 5))  # Not known to vary > 0.2 mag
+              )
+        return ok
+
     def get_initial_guide_candidates(self):
         """
         Create a candidate list from the available stars in the field.
@@ -297,16 +318,9 @@ class GuideTable(ACACatalogTable):
 
         # Use the primary selection filter from acq, but allow bad color
         # and limit to brighter stars
-        ok = ((stars['CLASS'] == 0) &
-              (stars['mag'] > 5.9) &
-              (stars['mag'] < 10.3) &
+        ok = (self.get_candidates_filter(stars) &
               (np.abs(stars['row']) < ACA.max_ccd_row) &  # Max usable row
-              (np.abs(stars['col']) < ACA.max_ccd_col) &  # Max usable col
-              (stars['mag_err'] < 1.0) &  # Mag err < 1.0 mag
-              (stars['ASPQ1'] < 20) &  # Less than 1 arcsec offset from nearby spoiler
-              (stars['ASPQ2'] == 0) &  # Proper motion less than 0.5 arcsec/yr
-              (stars['POS_ERR'] < 3000) &  # Position error < 3.0 arcsec
-              ((stars['VAR'] == -9999) | (stars['VAR'] == 5))  # Not known to vary > 0.2 mag
+              (np.abs(stars['col']) < ACA.max_ccd_col)  # Max usable col
               )
 
         # Mark stars that are off chip

--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -158,7 +158,7 @@ def make_cand_acqs_report(acqs, cand_acqs, events, context, obsdir):
 
         fig = plot_aca.plot_stars(acqs.att, stars=acqs.stars,
                                   catalog=acqs.cand_acqs,
-                                  bad_stars=acqs.bad_stars)
+                                  bad_stars=acqs.bad_stars_mask)
         # When Ska3 has matplotlib 2.2+ then just use `filename`
         fig.savefig(str(filename))
         plt.close(fig)
@@ -284,7 +284,7 @@ def make_obsid_summary(acqs, events, context, obsdir):
         ax = fig.add_subplot(1, 1, 1)
         plot_aca.plot_stars(acqs.att, stars=acqs.stars,
                             catalog=acqs,
-                            bad_stars=acqs.bad_stars, ax=ax)
+                            bad_stars=acqs.bad_stars_mask, ax=ax)
         # When Ska3 has matplotlib 2.2+ then just use `filename`
         plt.savefig(str(filename))
         plt.close(fig)
@@ -325,7 +325,6 @@ def make_report(obsid, rootdir='.'):
 
     # Get information that is not stored in the acqs pickle for space reasons
     acqs.stars = StarsTable.from_agasc(acqs.att, date=acqs.date)
-    _, acqs.bad_stars = acqs.get_acq_candidates(acqs.stars)
 
     events = make_events(acqs)
     context['events'] = events
@@ -365,7 +364,7 @@ def plot_spoilers(acq, acqs, filename=None):
     ok = ((np.abs(stars['yang'] - acq['yang']) < plot_hw) &
           (np.abs(stars['zang'] - acq['zang']) < plot_hw))
     stars = stars[ok]
-    bad_stars = acqs.bad_stars[ok]
+    bad_stars = acqs.bad_stars_mask[ok]
 
     fig = plt.figure(figsize=(5, 5))
     ax = fig.add_subplot(1, 1, 1)

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -185,8 +185,7 @@ def get_test_cand_acqs():
         acqs.p_man_errs = ACQ.p_man_errs['120-180']
         acqs.t_ccd = -10.0
         stars = get_test_stars()
-        CACHE['cand_acqs'], bads = acqs.get_acq_candidates(stars)
-        # Don't care about bads for testing
+        CACHE['cand_acqs'] = acqs.get_acq_candidates(stars)
     return CACHE['cand_acqs'].copy()
 
 

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -1033,12 +1033,19 @@ def test_0_5_degree_man_angle_bin_diff_t_ccd():
 
 
 def test_bad_star_list():
+    """
+    Test that a star with ID in the bad star list is not selected.
+    """
     bad_id = 39980640
     dark = DARK40.copy()
     stars = StarsTable.empty()
     stars.add_fake_constellation(mag=np.linspace(9, 10.3, 5), n_stars=5)
+    # Bright star that would normally be selected
     stars.add_fake_star(yang=100, zang=100, mag=6.5, id=bad_id)
     kwargs = mod_std_info(stars=stars, dark=dark,
                           n_guide=0, n_fid=0, n_acq=8, man_angle=4.8)
     acqs = get_acq_catalog(**kwargs)
     assert bad_id not in acqs['id']
+
+    idx = acqs.stars.get_id_idx(bad_id)
+    assert acqs.bad_stars_mask[idx]


### PR DESCRIPTION
Plotting was kinda broken with regards to bad stars and the attempt to use just a single method for all classes didn't cut it.  This PR fixes things up by introducing class-specific plot methods that do the right thing.  Along the way I did a lot of refactoring and re-organizing:

- Add a `bad_stars_mask` property
- Add a `get_candidates_mask` method that indicates acceptable candidates (apart from spatial filtering)
- Add a `catalog_type` class attribute to indicate the type of catalog represented by the class.
- Add a helper method `get_catalog_for_plot` (minor catalog munge for plotting)

There was a reason for the madness, namely in development of #216 I was frustrated by the bugs and not being able to evaluate by eye whether a particular candidate should be acceptable at a different roll.

This supercedes #222.
