### PR TITLE
Add bad_stars property

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -72,7 +72,7 @@ def get_acq_catalog(obsid=0, **kwargs):
     acqs.p_man_errs = np.array([get_p_man_err(man_err, acqs.man_angle)
                                 for man_err in ACQ.man_errs])
 
-    acqs.cand_acqs, acqs.bad_stars = acqs.get_acq_candidates(acqs.stars)
+    acqs.cand_acqs = acqs.get_acq_candidates(acqs.stars)
 
     # Fill in the entire acq['probs'].p_acqs table (which is actual a dict of keyed by
     # (box_size, man_err) tuples).
@@ -297,7 +297,6 @@ class AcqTable(ACACatalogTable):
               (np.abs(stars['col']) < ACA.max_ccd_col)  # Max usable col
               )
 
-        bads = ~ok
         cand_acqs = stars[ok]
 
         cand_acqs.sort('mag')
@@ -357,7 +356,7 @@ class AcqTable(ACACatalogTable):
         cand_acqs['imposters_box'] = np.full(n_cand, None)
         cand_acqs['box_sizes'] = box_sizes_list
 
-        return cand_acqs, bads
+        return cand_acqs
 
     def get_box_sizes(self, cand_acqs):
         """Get the available box sizes for each cand_acq as all those with size <= the

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -575,6 +575,19 @@ class ACACatalogTable(BaseCatalogTable):
         plot_stars(attitude=self.att, catalog=self, ax=ax, **stars_kwargs)
         plt.show()
 
+    def get_candidates_filter(self, stars):
+        return np.zeros(len(stars), dtype=bool)
+
+    @property
+    def bad_stars(self):
+        if not hasattr(self, '_bad_stars'):
+            self._bad_stars = self.get_candidates_filter(self.stars)
+        return self._bad_stars
+
+    @bad_stars.setter
+    def bad_stars(self, value):
+        self._bad_stars = value
+
     @property
     def dither(self):
         return None
@@ -890,6 +903,16 @@ class StarsTable(BaseCatalogTable):
 
         plot_stars(attitude=self.att, stars=self, ax=ax)
         plt.show()
+
+    @property
+    def bad_stars(self):
+        if not hasattr(self, '_bad_stars'):
+            self._bad_stars = np.zeros(len(self), dtype=bool)
+        return self._bad_stars
+
+    @bad_stars.setter
+    def bad_stars(self, value):
+        self._bad_stars = value
 
     @classmethod
     def from_agasc(cls, att, date=None, radius=1.2, logger=None):

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -576,12 +576,12 @@ class ACACatalogTable(BaseCatalogTable):
         plt.show()
 
     def get_candidates_filter(self, stars):
-        return np.zeros(len(stars), dtype=bool)
+        return np.ones(len(stars), dtype=bool)
 
     @property
     def bad_stars(self):
         if not hasattr(self, '_bad_stars'):
-            self._bad_stars = self.get_candidates_filter(self.stars)
+            self._bad_stars = ~self.get_candidates_filter(self.stars)
         return self._bad_stars
 
     @bad_stars.setter

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -288,6 +288,27 @@ class GuideTable(ACACatalogTable):
 
         super().process_include_ids(cand_guides, stars[ok])
 
+    @staticmethod
+    def get_candidates_filter(stars):
+        """Get base filter for acceptable candidates.
+
+        This does not include spatial filtering.
+
+        :param stars: StarsTable
+        :returns: bool mask of acceptable stars
+
+        """
+        ok = ((stars['CLASS'] == 0) &
+              (stars['mag'] > 5.9) &
+              (stars['mag'] < 10.3) &
+              (stars['mag_err'] < 1.0) &  # Mag err < 1.0 mag
+              (stars['ASPQ1'] < 20) &  # Less than 1 arcsec offset from nearby spoiler
+              (stars['ASPQ2'] == 0) &  # Proper motion less than 0.5 arcsec/yr
+              (stars['POS_ERR'] < 3000) &  # Position error < 3.0 arcsec
+              ((stars['VAR'] == -9999) | (stars['VAR'] == 5))  # Not known to vary > 0.2 mag
+              )
+        return ok
+
     def get_initial_guide_candidates(self):
         """
         Create a candidate list from the available stars in the field.
@@ -297,16 +318,9 @@ class GuideTable(ACACatalogTable):
 
         # Use the primary selection filter from acq, but allow bad color
         # and limit to brighter stars
-        ok = ((stars['CLASS'] == 0) &
-              (stars['mag'] > 5.9) &
-              (stars['mag'] < 10.3) &
+        ok = (self.get_candidates_filter(stars) &
               (np.abs(stars['row']) < ACA.max_ccd_row) &  # Max usable row
-              (np.abs(stars['col']) < ACA.max_ccd_col) &  # Max usable col
-              (stars['mag_err'] < 1.0) &  # Mag err < 1.0 mag
-              (stars['ASPQ1'] < 20) &  # Less than 1 arcsec offset from nearby spoiler
-              (stars['ASPQ2'] == 0) &  # Proper motion less than 0.5 arcsec/yr
-              (stars['POS_ERR'] < 3000) &  # Position error < 3.0 arcsec
-              ((stars['VAR'] == -9999) | (stars['VAR'] == 5))  # Not known to vary > 0.2 mag
+              (np.abs(stars['col']) < ACA.max_ccd_col)  # Max usable col
               )
 
         # Mark stars that are off chip

--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -325,7 +325,6 @@ def make_report(obsid, rootdir='.'):
 
     # Get information that is not stored in the acqs pickle for space reasons
     acqs.stars = StarsTable.from_agasc(acqs.att, date=acqs.date)
-    _, acqs.bad_stars = acqs.get_acq_candidates(acqs.stars)
 
     events = make_events(acqs)
     context['events'] = events

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -185,8 +185,7 @@ def get_test_cand_acqs():
         acqs.p_man_errs = ACQ.p_man_errs['120-180']
         acqs.t_ccd = -10.0
         stars = get_test_stars()
-        CACHE['cand_acqs'], bads = acqs.get_acq_candidates(stars)
-        # Don't care about bads for testing
+        CACHE['cand_acqs'] = acqs.get_acq_candidates(stars)
     return CACHE['cand_acqs'].copy()
 
 


### PR DESCRIPTION
This gives a consistent `bad_stars` property that can be used for plotting.  In particular it will correctly show which stars are potential candidates and which are not.  This is a different set for guide and acq.