### PR TITLE
Add n_stars method for catalog fractional count

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -105,12 +105,11 @@ class GuideTable(ACACatalogTable):
         SSAWG.  The implementation here does a piecewise linear interpolation
         between the reference mag - fractional count points instead of the
         original "threshold interpolation" (nearest neighbor mag <= reference
-        mag).
+        mag).  Approved at 16-Jan-2019 SSAWG.
 
         :returns: fractional count
 
         """
-        # The bright limit does not scale.
         t_ccd = self.t_ccd
         mag1 = snr_mag_for_t_ccd(t_ccd, ref_mag=10.0, ref_t_ccd=-10.9)
         mag2 = snr_mag_for_t_ccd(t_ccd, ref_mag=10.2, ref_t_ccd=-10.9)


### PR DESCRIPTION
This makes the guide fractional count use piecewise linear interpolation instead of mag thresholds for computing the count.  It doesn't really make sense that a 10.29 star counts as 0.5 stars and a 10.31 star is 0.0.  In reality they are functionally equivalent.  

Here is a comparison (taken from a notebook referenced in the 2019-01-09 SSAWG notes).  Red is the new curve, magenta is the old one.  The new implementation is exactly the same at the reference values, but on average more optimistic.  From analysis in the notebook this is probably justified but needs discussion.

![image](https://user-images.githubusercontent.com/348089/50564632-6eae9700-0cf4-11e9-8c3d-59aa50fcbebb.png)

Note that I'm using this now in #216 as the thresholding obscures changes in the guide catalog.