### PR TITLE
Make AcqProbs ref to parent acqs be a weakref

### DIFF
--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -96,6 +96,15 @@ class FidTable(ACACatalogTable):
 
     @acqs.setter
     def acqs(self, val):
+        """Note some subtlety here - this is using a standard __dict__ attribute
+        ``_acqs`` instead of a MetaAttribute, and thus the weakref here is
+        ignored in pickling because Table does not pickle the __dict__, it only
+        pickles the columns and the ``meta`` attribute.
+
+        This overrides the base class definition which *does* store the value in
+        ``.meta`` so it gets into the pickle.
+
+        """
         self._acqs = weakref.ref(val)
 
     @property

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -198,6 +198,10 @@ def test_pickle():
             else:
                 assert val == val2
 
+    assert np.isclose(aca.acqs.calc_p_safe(), aca2.acqs.calc_p_safe(),
+                      atol=0, rtol=1e-6)
+    assert aca.acqs.fid_set == aca2.acqs.fid_set
+
 
 def test_big_sim_offset():
     """

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -165,6 +165,17 @@ def test_big_dither_from_mica_starcheck():
 
 
 def test_pickle():
+    """Test that ACA, guide, acq, and fid catalogs round-trip through pickling.
+
+    Known attributes that do NOT round-trip are below.  None of these are
+    required for post-facto catalog evaluation and currently the reporting code
+    handles ``stars`` and ``dark``.
+
+    - stars
+    - dark
+    - aca.fids.acqs
+
+    """
     stars = StarsTable.empty()
     stars.add_fake_constellation(mag=10.0, n_stars=5)
     aca = get_aca_catalog(stars=stars, raise_exc=True, **STD_INFO)
@@ -198,6 +209,10 @@ def test_pickle():
             else:
                 assert val == val2
 
+    # Test that calc_p_safe() gives the same answer, which implicitly tests
+    # that the AcqTable.__setstate__ unpickling code has the right (weak)
+    # reference to acqs within each AcqProbs object.  This also tests
+    # that acqs.p_man_err and acqs.fid_set are the same.
     assert np.isclose(aca.acqs.calc_p_safe(), aca2.acqs.calc_p_safe(),
                       atol=0, rtol=1e-6)
     assert aca.acqs.fid_set == aca2.acqs.fid_set

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pickle
 import pytest
 import numpy as np
 from astropy.io import ascii
@@ -236,6 +237,16 @@ def test_alias_attributes(cls, attr):
         setattr(obj, attr + suffix, val)
         assert getattr(obj, attr) == exp
         assert getattr(obj, attr + suffix) == exp
+
+
+def test_pickle_stars():
+    """Test that pickling a StarsTable object roundtrips"""
+    att = [1, 2, 3]
+    stars = StarsTable.from_agasc(att)
+    stars2 = pickle.loads(pickle.dumps(stars))
+    assert stars2.att == att
+    assert stars2.colnames == stars.colnames
+    assert repr(stars) == repr(stars2)
 
 
 def test_starstable_from_stars():


### PR DESCRIPTION
This fixes a memory leak in acq star selection.  Without this fix I see memory increasing at about 4 Mb/catalog.  (I've done analysis runs that selected in excess of 1000 catalogs, but I guess I have enough memory to not have noticed.)  With this fix in place the memory used hovers between 300-400 Mb even after 500 catalogs selected.

Currently this fails 3 tests all related to pickling.  Weakrefs cannot be pickled so I need to figure a workaround.  There is also a lower-level question of performance using a weakref instead of direct ref.

cc: @mbaski 