### PR TITLE
Backport #212 improve report generation to 4.3.x

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -208,6 +208,19 @@ class AcqTable(ACACatalogTable):
             out = int(self.get_log_p_2_or_fewer() <= np.log10(CHAR.acq_prob))
         return out
 
+    def make_report(self, rootdir='.'):
+        """
+        Make summary HTML report for acq selection process and outputs.
+
+        Output is in ``<rootdir>/obs<obsid>/acq/index.html`` plus related images
+        in that directory.
+
+        :param rootdir: root directory for outputs
+
+        """
+        from .report_acq import make_report
+        make_report(self, rootdir=rootdir)
+
     def update_p_acq_column(self):
         """
         Update (in-place) the marginalized acquisition probability column

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -153,6 +153,19 @@ class ACATable(ACACatalogTable):
                    self.fids.thumbs_up &
                    self.guides.thumbs_up)
 
+    def make_report(self, rootdir='.'):
+        """
+        Make summary HTML report for acq and guide selection process and outputs.
+
+        Outputs are in ``<rootdir>/obs<obsid>/{acq,guide}/index.html`` plus related
+        images in that directory.
+
+        :param rootdir: root directory for outputs
+
+        """
+        self.acqs.make_report(rootdir=rootdir)
+        self.guides.make_report(rootdir=rootdir)
+
     def optimize_acqs_fids(self):
         """
         Concurrently optimize acqs and fids in the case where there is not

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -106,6 +106,19 @@ class GuideTable(ACACatalogTable):
             out = int(count >= GUIDE_CHAR.min_guide_count)
         return out
 
+    def make_report(self, rootdir='.'):
+        """
+        Make summary HTML report for guide selection process and outputs.
+
+        Output is in ``<rootdir>/obs<obsid>/guide/index.html`` plus related images
+        in that directory.
+
+        :param rootdir: root directory for outputs
+
+        """
+        from .report_guide import make_report
+        make_report(self, rootdir=rootdir)
+
     def run_search_stages(self):
         """
         Run through search stages to select stars with priority given to "better"

--- a/proseco/index_template.html
+++ b/proseco/index_template.html
@@ -40,12 +40,16 @@ table.table-striped td {
 <h1> Obsid {{obsid}} at {{date}}</h1>
 
 <table class="table-striped">
-  <tr>  <td> <b>RA</b> </td> <td> {{ att[0] }} </td> </tr>
-  <tr>  <td> <b>Dec</b> </td> <td> {{ att[1] }} </td> </tr>
-  <tr>  <td> <b>Roll</b> </td> <td> {{ att[2] }} </td> </tr>
-  <tr>  <td> <b>T_ccd</b> </td> <td> {{ t_ccd }} </td> </tr>
-  <tr>  <td> <b>Man angle</b> </td> <td> {{ man_angle }} </td> </tr>
-  <tr>  <td> <b>Dither</b> </td> <td> {{ dither }} </td> </tr>
+  <tr>  <td> <b>ra</b> </td> <td> {{ att[0] }} </td> </tr>
+  <tr>  <td> <b>dec</b> </td> <td> {{ att[1] }} </td> </tr>
+  <tr>  <td> <b>roll</b> </td> <td> {{ att[2] }} </td> </tr>
+  <tr>  <td> <b>t_ccd</b> </td> <td> {{ t_ccd_acq }} C</td> </tr>
+  <tr>  <td> <b>man angle</b> </td> <td> {{ man_angle }} deg</td> </tr>
+  <tr>  <td> <b>dither (y, z)</b> </td> <td> {{ dither_acq.y }}, {{ dither_acq.z }} arcsec</td> </tr>
+  <tr>  <td> <b>n_acq</b> </td> <td> {{ n_acq }} </td> </tr>
+  {% if include_ids %} <tr>  <td> <b>include_ids</b> </td> <td> {{ include_ids }} </td> </tr> {% endif %}
+  {% if include_halfws %} <tr>  <td> <b>include_halfws</b> </td> <td> {{ include_halfws }} arcsec </td> </tr> {% endif %}
+  {% if exclude_ids %} <tr>  <td> <b>exclude_ids</b> </td> <td> {{ exclude_ids }} </td> </tr> {% endif %}
 </table>
 
 <table>

--- a/proseco/index_template_guide.html
+++ b/proseco/index_template_guide.html
@@ -1,0 +1,102 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+  <head>
+    <title>Proseco guide star selection summary</title>
+    <link href="/mta/ASPECT/aspect.css" rel="stylesheet" type="text/css" media="all" />
+  <style>
+h1,h2,h3,h4 {
+  color: #990000;
+}
+
+table.table-striped {
+        border-width: thin thin thin thin;
+        border-spacing: 1px;
+        border-style: outset outset outset outset;
+        border-color: gray gray gray gray;
+        border-collapse: separate;
+        background-color: white;
+}
+
+table.table-striped th {
+        border-width: 1px 1px 1px 1px;
+        padding: 1px 3px 1px 3px;
+        border-color: gray;
+        border-style: inset;
+}
+table.table-striped td {
+        border-width: 1px 1px 1px 1px;
+        padding: 1px 3px 1px 3px;
+        border-style: inset;
+        border-color: gray;
+        text-align: right;
+}
+</style>
+  </head>
+
+  <body>
+
+<!--#include virtual="/mta/ASPECT/header.html"-->
+
+<h1> Obsid {{obsid}} at {{date}}</h1>
+
+<table class="table-striped">
+  <tr>  <td> <b>ra</b> </td> <td> {{ att[0] }} </td> </tr>
+  <tr>  <td> <b>dec</b> </td> <td> {{ att[1] }} </td> </tr>
+  <tr>  <td> <b>roll</b> </td> <td> {{ att[2] }} </td> </tr>
+  <tr>  <td> <b>t_ccd</b> </td> <td> {{ t_ccd_guide }} C</td> </tr>
+  <tr>  <td> <b>dither (y, z)</b> </td> <td> {{ dither_guide.y }}, {{ dither_guide.z }} arcsec</td> </tr>
+  <tr>  <td> <b>n_guide</b> </td> <td> {{ n_guide }} </td> </tr>
+  {% if include_ids %} <tr>  <td> <b>include_ids</b> </td> <td> {{ include_ids }} </td> </tr> {% endif %}
+  {% if exclude_ids %} <tr>  <td> <b>exclude_ids</b> </td> <td> {{ exclude_ids }} </td> </tr> {% endif %}
+</table>
+
+
+
+<h2> Guide star catalog </h2>
+
+<table>
+  <tr>
+    <td> {{ guides_table | safe }} </td>
+  </tr>
+</table>
+
+
+<h2> Candidates stars summary </h2>
+
+<table>
+  <tr>
+    <td> {{ cand_guides_table | safe }} </td>
+  </tr>
+</table>
+
+
+<h2> Star details </h2>
+<table>
+{% for star in cand_guides %}
+  <hr></hr>
+  <h3 id="{{star['id']}}"> AGASC ID {{ star['id'] }} ({{star['selected']}})</h3>
+
+  <table>
+
+    <tr><td>{{ star['guide_table'] | safe }}</td></tr>
+    <tr><td><img src="{{star['candidate_plot'] | safe}}"></td></tr>
+  </table>
+
+
+  <h4>Progress through star selection stages<h4>
+  <table>
+  {% for line in star['log'] %}
+  <tr>
+    <td><tt> {{line}} </tt></td>
+  </tr>
+  {% endfor %}
+  </table>
+{% endfor %}
+</table>
+
+
+<!--#include virtual="/mta/ASPECT/footer.html"-->
+<!--footer end-->
+
+  </body>
+</html>

--- a/proseco/report.py
+++ b/proseco/report.py
@@ -4,7 +4,6 @@
 from __future__ import division, print_function, absolute_import  # For Py2 compatibility
 
 from copy import copy, deepcopy
-import re
 from pathlib import Path
 
 import matplotlib
@@ -163,7 +162,6 @@ def make_cand_acqs_report(acqs, cand_acqs, events, context, obsdir):
     # Now plot figure
     filename = obsdir / 'candidate_stars.png'
     if not filename.exists():
-        print(f'Making candidate stars plot {filename}')
 
         # Pull a fast-one and mark the final selected ACQ stars as BOT so they
         # get a circle in the plot.  This might be confusing and need fixing
@@ -198,7 +196,6 @@ def make_acq_star_details_report(acqs, cand_acqs, events, context, obsdir):
     context['cand_acqs'] = []
 
     for ii, acq in enumerate(cand_acqs):
-        print('Doing detail for star {}'.format(acq['id']))
         # Local context dict for each cand_acq star
         cca = {'id': acq['id'],
                'selected': 'SELECTED' if acq['id'] in acqs['id'] else 'not selected'}
@@ -293,7 +290,7 @@ def make_obsid_summary(acqs, events, context, obsdir):
     context['acqs_table'] = table_to_html(acqs_table)
 
     basename = 'acq_stars.png'
-    filename = obsdir / basename
+    filename = obsdir / 'acq' / basename
     context['acq_stars_plot'] = basename
     if not filename.exists():
         fig = plt.figure(figsize=(4, 4))
@@ -304,18 +301,41 @@ def make_obsid_summary(acqs, events, context, obsdir):
                             bad_stars=acqs.bad_stars, ax=ax)
         # When Ska3 has matplotlib 2.2+ then just use `filename`
         plt.savefig(str(filename))
-        plt.close()
+        plt.close(fig)
 
 
 def make_report(obsid, rootdir='.'):
-    rootdir = Path(rootdir)
-    print(f'Processing obsid {obsid}')
+    """
+    Make summary HTML report for acq star selection.
 
-    obsdir = rootdir / f'obs{obsid:05}'
-    acqs = AcqTable.from_pickle(obsid, rootdir)
+    The first arg ``obsid`` can be an obsid (int) or a ``AcqTable`` object.
+    For ``int`` the acq table is read from ``<rootdir>/obs<obsid>/acq.pkl``.
+
+    Output is in ``<rootdir>/obs<obsid>/acq/index.html`` plus related images
+    in that directory.
+
+    :param obsid: int obsid or AcqTable instance
+    :param rootdir: root directory for outputs
+
+    :returns: AcqTable object (mostly for testing)
+    """
+    rootdir = Path(rootdir)
+    if isinstance(obsid, AcqTable):
+        acqs = obsid
+        obsid = acqs.obsid
+    else:
+        acqs = AcqTable.from_pickle(obsid, rootdir)
     cand_acqs = acqs.cand_acqs
 
+    # Define and make directories as needed
+    obsdir = rootdir / f'obs{obsid:05}'
+    outdir = obsdir / 'acq'
+    outdir.mkdir(exist_ok=True, parents=True)
+
     context = copy(acqs.meta)
+    context['include_ids'] = ", ".join([str(val) for val in acqs.include_ids])
+    context['include_halfws'] = ", ".join([str(val) for val in acqs.include_halfws])
+    context['exclude_ids'] = ", ".join([str(val) for val in acqs.exclude_ids])
 
     # Get information that is not stored in the acqs pickle for space reasons
     acqs.stars = StarsTable.from_agasc(acqs.att, date=acqs.date)
@@ -326,15 +346,15 @@ def make_report(obsid, rootdir='.'):
 
     make_obsid_summary(acqs, events, context, obsdir)
     make_p_man_errs_report(context)
-    make_cand_acqs_report(acqs, cand_acqs, events, context, obsdir)
+    make_cand_acqs_report(acqs, cand_acqs, events, context, outdir)
     make_initial_cat_report(events, context)
-    make_acq_star_details_report(acqs, cand_acqs, events, context, obsdir)
+    make_acq_star_details_report(acqs, cand_acqs, events, context, outdir)
     make_optimize_catalog_report(events, context)
 
     template_file = FILEDIR / 'index_template.html'
     template = Template(open(template_file, 'r').read())
     out_html = template.render(context)
-    out_filename = obsdir / 'index.html'
+    out_filename = outdir / 'index.html'
     with open(out_filename, 'w') as fh:
         fh.write(out_html)
 
@@ -486,5 +506,6 @@ def plot_imposters(acq, dark, dither, vmin=100, vmax=2000,
     if filename is not None:
         # When Ska3 has matplotlib 2.2+ then just use `filename`
         plt.savefig(str(filename), pad_inches=0.0)
+    plt.close(fig)
 
     return img, ax

--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -3,6 +3,7 @@
 
 from __future__ import division, print_function, absolute_import  # For Py2 compatibility
 
+import re
 from copy import copy, deepcopy
 from pathlib import Path
 

--- a/proseco/report_guide.py
+++ b/proseco/report_guide.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import re
 from copy import copy
 from pathlib import Path
 
@@ -16,8 +17,9 @@ from chandra_aca.aca_image import ACAImage, AcaPsfLibrary
 from chandra_aca.transform import mag_to_count_rate
 from mica.archive.aca_dark.dark_cal import get_dark_cal_image
 
-from .core import StarsTable, table_to_html
-from .guide import GuideTable, get_ax_range, GUIDE
+from .core import StarsTable
+from .guide import GuideTable, get_ax_range
+from .guide import GUIDE_CHAR as GUIDE
 
 # Do reporting for at-most MAX_CAND candidates
 MAX_CAND = 50
@@ -27,6 +29,23 @@ COLS = ['id', 'stage', 'forced',
         'COLOR1', 'ASPQ1', 'MAG_ACA_ERR']
 FILEDIR = Path(__file__).parent
 APL = AcaPsfLibrary()
+
+
+def table_to_html(tbl):
+    """
+    Make an HTML representation of a table
+    :param tbl: astropy Table
+    :returns: str
+    """
+    out = tbl._base_repr_(html=True, max_width=-1,
+                          show_dtype=False, descr_vals=[],
+                          max_lines=-1, tableclass='table-striped')
+    # Undo HTML sanitizing to allow raw HTML in table elements
+    out = re.sub(r'&quot;', '"', out)
+    out = re.sub(r'&lt;', '<', out)
+    out = re.sub(r'&gt;', '>', out)
+
+    return out
 
 
 def make_report(obsid, rootdir='.'):
@@ -109,7 +128,7 @@ def make_report(obsid, rootdir='.'):
     context['cand_guides_table'] = table_to_html(cand_guides_table)
 
     # Make the HTML
-    template_file = FILEDIR / GUIDE.index_template_file
+    template_file = FILEDIR / 'index_template_guide.html'
     template = Template(open(template_file, 'r').read())
     out_html = template.render(context)
     out_filename = outdir / 'index.html'

--- a/proseco/report_guide.py
+++ b/proseco/report_guide.py
@@ -1,0 +1,313 @@
+# coding: utf-8
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from copy import copy
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('agg')
+
+from jinja2 import Template
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import patches
+
+from chandra_aca.aca_image import ACAImage, AcaPsfLibrary
+from chandra_aca.transform import mag_to_count_rate
+from mica.archive.aca_dark.dark_cal import get_dark_cal_image
+
+from .core import StarsTable, table_to_html
+from .guide import GuideTable, get_ax_range, GUIDE
+
+# Do reporting for at-most MAX_CAND candidates
+MAX_CAND = 50
+COLS = ['id', 'stage', 'forced',
+        'mag', 'mag_err',
+        'yang', 'zang', 'row', 'col',
+        'COLOR1', 'ASPQ1', 'MAG_ACA_ERR']
+FILEDIR = Path(__file__).parent
+APL = AcaPsfLibrary()
+
+
+def make_report(obsid, rootdir='.'):
+    """
+    Make summary HTML report for guide star selection.
+
+    The first arg ``obsid`` can be an obsid (int) or a ``GuideTable`` object.
+    For ``int`` the guide table is read from ``<rootdir>/obs<obsid>/guide.pkl``.
+
+    Output is in ``<rootdir>/obs<obsid>/guide/index.html`` plus related images
+    in that directory.
+
+    :param obsid: int obsid or GuideTable instance
+    :param rootdir: root directory for outputs
+
+    :returns: GuideTable object (mostly for testing)
+    """
+    rootdir = Path(rootdir)
+
+    if isinstance(obsid, GuideTable):
+        guides = obsid
+        obsid = guides.obsid
+    else:
+        guides = GuideTable.from_pickle(obsid, rootdir)
+
+    # Define and make directories as needed
+    obsdir = rootdir / f'obs{obsid:05}'
+    outdir = obsdir / 'guide'
+    outdir.mkdir(exist_ok=True, parents=True)
+
+    cand_guides = guides.cand_guides.copy()
+    cand_guides['sort_stage'] = cand_guides['stage']
+    cand_guides['sort_stage'][cand_guides['stage'] == -1] = 1000
+    cand_guides.sort(['sort_stage', 'mag'])
+    if len(cand_guides) > MAX_CAND:
+        cand_guides = cand_guides[0:MAX_CAND]
+
+    context = copy(guides.meta)
+    context['include_ids'] = ", ".join([str(val) for val in guides.include_ids])
+    context['exclude_ids'] = ", ".join([str(val) for val in guides.exclude_ids])
+
+    # Get information that is not stored in the acqs pickle for space reasons
+    guides.stars = StarsTable.from_agasc(guides.att, date=guides.date)
+    guides.dark = get_dark_cal_image(date=guides.date, select='before',
+                                     t_ccd_ref=guides.t_ccd)
+
+    # For include/exclude stars, add some bookkeeping (the forced column)
+    cand_guides['forced'] = False
+    for force_include in guides.include_ids_guide:
+        cand_guides['forced'][cand_guides['id'] == force_include] = True
+    for ex_cand_id in guides.exclude_ids_guide:
+        # Stars that were excluded via exclude_ids are not kept as candidates
+        # and have no debugging information.  Add them back at least to see
+        # some of their properties in the report.
+        match = guides.stars[guides.stars['id'] == ex_cand_id]
+        if len(match) > 0:
+            ex_cand = match[0]
+        cand_guides.add_row()
+        for col in cand_guides.colnames:
+            if col in ex_cand.colnames:
+                cand_guides[col][-1] = ex_cand[col]
+        cand_guides['stage'][-1] = -1
+        cand_guides['forced'][-1] = True
+
+    make_cand_report(guides, cand_guides, context, outdir)
+
+    # Guide star table
+    cols = COLS.copy()
+    cols.remove('forced')
+    cols.remove('MAG_ACA_ERR')
+    guides_table = guides[cols]
+    guides_table['id'] = ['<a href=#{0}>{0}</a>'.format(guide['id'])
+                          for guide in guides_table]
+    context['guides_table'] = table_to_html(guides_table)
+
+    # Candidate guides table
+    cand_guides_table = cand_guides[COLS]
+    cand_guides_table['id'] = ['<a href=#{0}>{0}</a>'.format(cand_guide['id'])
+                               for cand_guide in cand_guides]
+    context['cand_guides_table'] = table_to_html(cand_guides_table)
+
+    # Make the HTML
+    template_file = FILEDIR / GUIDE.index_template_file
+    template = Template(open(template_file, 'r').read())
+    out_html = template.render(context)
+    out_filename = outdir / 'index.html'
+    with open(out_filename, 'w') as fh:
+        fh.write(out_html)
+
+    return guides
+
+
+def make_cand_report(guides, cand_guides, context, obsdir):
+
+    n_stages = np.max(cand_guides['stage'])
+    context['cand_guides'] = []
+    for ii, guide in enumerate(cand_guides):
+        select = 'SELECTED' if guide['id'] in guides['id'] else 'not selected'
+
+        # Add debugging information if the star was in include/exclude lists
+        if (guide['id'] in guides.include_ids_guide) or (guide['id'] in guides.exclude_ids_guide):
+            select = select + ' - forced with include/exclude'
+        rep = {
+            'id': guide['id'],
+            'selected': select
+        }
+        log = reject_info_to_report(guide['id'], guides.reject_info)
+        if guide['stage'] != -1:
+            if guide['stage'] == 0:
+                log.append(f"FORCE Selected in stage 0")
+            else:
+                log.append(f"Selected in stage {guide['stage']}")
+            if guide['id'] not in guides['id']:
+                log.append(f"Did not make final cut of {len(guides)} stars")
+        else:
+            log.append(f"Not selected in any stage ({n_stages} stages run)")
+        rep['log'] = log
+        guide_table = cand_guides[COLS][ii:ii + 1].copy()
+        guide_table['id'] = ['<a href="http://kadi.cfa.harvard.edu/star_hist/?agasc_id={0}" '
+                             'target="_blank">{0}</a>'
+                             .format(g['id']) for g in guide_table]
+        rep['guide_table'] = table_to_html(guide_table)
+
+        # Make the star detail plot
+        basename = f'guide_candidate_{guide["id"]}.png'
+        filename = obsdir / basename
+        rep['candidate_plot'] = basename
+        if not filename.exists():
+            plot(guide, guides, filename=filename)
+        context['cand_guides'].append(rep)
+
+
+def reject_info_to_report(starid, reject_info):
+    """
+    For a given agasc_id, get all of the related "reject" info in an array
+    """
+    log = []
+    for entry in reject_info:
+        if entry['id'] != starid:
+            continue
+        log.append(f"Not selected stage {entry['stage']}: {entry['text']}")
+    return log
+
+
+def plot(guide, cand_guides, filename=None):
+    """
+    For a given candidate guide, make a plot of with a one subplot of possible spoiler stars
+    and another subplot of the region of the dark map that would be dithered over.
+    """
+    # NOTE: all coordinates in plot funcs are "edge" coordinates.  Indexing an
+    # ACAImage pixel using `.aca` coordinates implies using the row, col
+    # coordinate of the lower-left corner of that pixel.
+
+    fig = plt.figure(figsize=(8, 4))
+
+    # First plot: star spoilers
+    ax = fig.add_subplot(1, 2, 1)
+    plot_spoilers(guide, cand_guides, ax)
+
+    # Second plot: hot pixel imposters
+    ax = fig.add_subplot(1, 2, 2)
+    plot_imposters(guide, cand_guides, ax)
+
+    plt.tight_layout()
+    if filename is not None:
+        # When Ska3 has matplotlib 2.2+ then just use `filename`
+        plt.savefig(str(filename), pad_inches=0.0)
+
+    plt.close(fig)
+
+
+def plot_spoilers(guide, cand_guides, ax):
+    """
+    Make the spoilers plot for a given `guide` candidate.
+    """
+    # Define bounds of spoiler image plot: halfwidth, center, lower-left corner
+    hw = 10
+    rowc = int(round(guide['row']))
+    colc = int(round(guide['col']))
+    row0 = rowc - hw
+    col0 = colc - hw
+
+    # Pixel image canvas for plot
+    region = ACAImage(np.zeros((hw * 2, hw * 2)),
+                      row0=row0,
+                      col0=col0)
+
+    # Get spoilers
+    stars = cand_guides.stars
+    ok = ((np.abs(guide['row'] - stars['row']) < hw) &
+          (np.abs(guide['col'] - stars['col']) < hw) &
+          (stars['id'] != guide['id']))
+    spoilers = stars[ok]
+
+    # Add to image
+    for spoil in spoilers:
+        spoil_img = APL.get_psf_image(row=spoil['row'], col=spoil['col'], pix_zero_loc='edge',
+                                      norm=mag_to_count_rate(spoil['mag']))
+        region = region + spoil_img.aca
+
+    # Get vmax from max pix value, but round to nearest 100, and create the image
+    vmax = np.max(region).clip(100)
+    vmax = np.ceil(vmax / 100) * 100
+    ax.imshow(region.transpose(), cmap='hot', origin='lower', vmin=1, vmax=vmax,
+              extent=(row0, row0 + hw * 2, col0, col0 + hw * 2))
+
+    # Plot a box showing the 8x8 image boundaries
+    x = rowc - 4
+    y = colc - 4
+    patch = patches.Rectangle((x, y), 8, 8, edgecolor='y', facecolor='none', lw=1)
+    ax.add_patch(patch)
+
+    # Make an empty box (no spoilers) or a cute 8x8 grid
+    if len(spoilers) == 0:
+        plt.text(rowc, colc, "No Spoilers", color='y', fontweight='bold',
+                 ha='center', va='center')
+    else:
+        for i in range(1, 8):
+            ax.plot([x, x + 8], [y + i, y + i], color='y', lw=1)
+            ax.plot([x + i, x + i], [y, y + 8], color='y', lw=1)
+
+    # Add mag text to each spoiler
+    for spoil in spoilers:
+        # Mag label above or below to ensure the label is in the image
+        dcol = -3 if (spoil['col'] > colc) else 3
+        plt.text(spoil['row'], spoil['col'] + dcol, f"mag={spoil['mag']:.1f}",
+                 color='y', fontweight='bold', ha='center', va='center')
+
+    plt.title(f"Spoiler stars (vmax={vmax:.0f})")
+    ax.set_xlabel('Row')
+    ax.set_ylabel('Column')
+
+
+def plot_imposters(guide, cand_guides, ax):
+    """
+    Make the hot pixel imposters plot for a given `guide` candidate.
+    """
+    # Figure out pixel region for dithered-over-pixels plot
+    row_extent = np.ceil(4 + cand_guides.dither.row)
+    col_extent = np.ceil(4 + cand_guides.dither.col)
+    rminus, rplus = get_ax_range(guide['row'], row_extent)
+    cminus, cplus = get_ax_range(guide['col'], col_extent)
+
+    # Pixel region of the guide
+    img = ACAImage(np.zeros(shape=(rplus - rminus, cplus - cminus)),
+                   row0=rminus, col0=cminus)
+    dark = ACAImage(cand_guides.dark, row0=-512, col0=-512)
+    img += dark.aca
+
+    # Pixel region of the guide plus some space for annotation
+    row0 = rminus - 4
+    col0 = cminus - 4
+    drow = (rplus - rminus) + 8
+    dcol = (cplus - cminus) + 8
+    canvas = ACAImage(np.zeros(shape=(drow, dcol)), row0=row0, col0=col0)
+    canvas += img.aca
+
+    ax.imshow(canvas.transpose(), interpolation='none', cmap='hot', origin='lower',
+              vmin=50, vmax=3000, extent=(row0, row0 + drow, col0, col0 + dcol))
+
+    # If force excluded, will not have imposter mag
+    if not (guide['forced'] and guide['stage'] == -1):
+        # Add max region with "mag"
+        x = guide['imp_r']
+        y = guide['imp_c']
+        patch = patches.Rectangle((x, y), 2, 2, edgecolor='y', facecolor='none', lw=1.5)
+        ax.add_patch(patch)
+        plt.text(row0 + drow / 2, col0 + dcol - 1, f"box 'mag' {guide['imp_mag']:.1f}",
+                 ha='center', va='center', color='y', fontweight='bold')
+
+    # Plot a box showing the 8x8 image boundaries
+    x = row0 + drow / 2 - 4
+    y = col0 + dcol / 2 - 4
+    patch = patches.Rectangle((x, y), 8, 8, edgecolor='y', facecolor='none', lw=1)
+    ax.add_patch(patch)
+
+    # Plot a box showing the 8x8 image boundaries
+    patch = patches.Rectangle((rminus, cminus), rplus - rminus, cplus - cminus,
+                              edgecolor='g', facecolor='none', lw=1)
+    ax.add_patch(patch)
+
+    ax.set_xlabel('Row')
+    ax.set_ylabel('Column')
+    plt.title("Dark Current in dither region")

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -519,13 +519,16 @@ def test_make_report(tmpdir):
 
     tmpdir = Path(tmpdir)
     obsdir = tmpdir / f'obs{obsid:05}'
+    outdir = obsdir / 'acq'
 
     acqs.to_pickle(rootdir=tmpdir)
 
     acqs2 = make_report(obsid, rootdir=tmpdir)
 
-    assert (obsdir / 'index.html').exists()
-    assert len(list(obsdir.glob('*.png'))) > 0
+    assert (outdir / 'index.html').exists()
+    assert (outdir / 'acq_stars.png').exists()
+    assert (outdir / 'candidate_stars.png').exists()
+    assert len(list(outdir.glob('*.png'))) > 0
 
     assert repr(acqs) == repr(acqs2)
     assert repr(acqs.cand_acqs) == repr(acqs2.cand_acqs)

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from chandra_aca.aca_image import AcaPsfLibrary
 from chandra_aca.transform import mag_to_count_rate, yagzag_to_pixels
 
-from ..report import make_report
+from ..report_acq import make_report
 from ..acq import (get_p_man_err, bin2x2, CHAR,
                    get_imposter_stars,
                    get_image_props,

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import mica.starcheck
 
-from .test_common import STD_INFO, mod_std_info, DARK40
+from .test_common import STD_INFO, mod_std_info, DARK40, OBS_INFO
 from ..core import StarsTable, ACACatalogTable
 from ..catalog import get_aca_catalog
 from ..fid import get_fid_catalog
@@ -452,3 +452,25 @@ def test_aca_acqs_include_exclude():
     guides = aca.guides
     assert guides.include_ids == include_ids
     assert guides.exclude_ids == exclude_ids
+
+
+def test_report_from_objects(tmpdir):
+    """
+    Test making guide and acq reports without the intermediate pickle.
+
+    This is just a sanity check that appropriate files are created.  More
+    detailed testing (including pickle round trip) is tested in test_guide
+    and test_acq.
+    """
+    rootdir = Path(tmpdir)
+
+    obsid = 20603
+    aca = get_aca_catalog(**OBS_INFO[obsid])
+    aca.guides.make_report(rootdir=rootdir)
+    aca.acqs.make_report(rootdir=rootdir)
+
+    obsdir = rootdir / f'obs{obsid:05}'
+    for subdir in 'acq', 'guide':
+        outdir = obsdir / subdir
+        assert(outdir / 'index.html').exists()
+        assert len(list(outdir.glob('*.png'))) > 0

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -12,9 +12,10 @@ from chandra_aca.transform import mag_to_count_rate, count_rate_to_mag
 
 from ..guide import (get_guide_catalog, check_spoil_contrib, get_pixmag_for_offset,
                      check_mag_spoilers, get_ax_range)
+from ..report_guide import make_report
 from ..characteristics_guide import mag_spoiler, CCD
 from ..core import StarsTable
-from .test_common import STD_INFO, mod_std_info
+from .test_common import STD_INFO, mod_std_info, OBS_INFO
 
 
 HAS_SC_ARCHIVE = Path(mica.starcheck.starcheck.FILES['data_root']).exists()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='proseco',
       version=__version__,
       zip_safe=False,
       packages=['proseco', 'proseco.tests'],
-      package_data={'proseco': ['index_template.html']},
+      package_data={'proseco': ['index_template*.html']},
       tests_require=['pytest'],
       cmdclass=cmdclass,
       )


### PR DESCRIPTION
This could be slightly controversial, but I was thinking about options for `aca_preview` to generate report pages for obsids that have warnings above a specified level (e.g. everything with `warning` or `critical` messages). This would presumably speed up diagnosis.

So I had the idea to just "quickly" backport #212 since the footprint of that PR is **outside of the core code apart from adding `make_report` methods**.   Unfortunately the merge had conflicts, and even after that there were a few post-cherry-pick issues that needed hand-fixing, so the "quickly" was optimistic.  But it does seem to be working now and passing all tests.

Until just now I didn't actually appreciate that 4.3.2 does not have any guide reporting.  So this PR is basically necessary if we want to have 4.3.x in ska3-flight and use it for production ACA review (starcheck) as well.  Somehow maintaining this concordance seems like the right thing.