### PR TITLE
Fix _baserepr_ so it doesn't deepcopy all meta

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -822,7 +822,8 @@ class ACACatalogTable(BaseCatalogTable):
             if name in names:
                 self[name].format = self._default_formats.pop(name)
 
-        return super(BaseCatalogTable, self[names])._base_repr_(*args, **kwargs)
+        tmp = self.__class__([self[name] for name in names], names=names, copy=False)
+        return super(BaseCatalogTable, tmp)._base_repr_(*args, **kwargs)
 
     def to_pickle(self, rootdir='.'):
         """


### PR DESCRIPTION
It turns out the base code to just print catalog tables nicely was doing some heavy lifting behind the scene.  Namely making a full copy of `meta`, which potentially includes star catalogs and dark cals.  This fixes that and is *necessary* for https://github.com/sot/sparkles/pull/48.