### PR TITLE
 Add support for dynamic limits via effective t_ccd

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -126,6 +126,12 @@ class AcqTable(ACACatalogTable):
     # Required attributes
     required_attrs = ('att', 'man_angle', 't_ccd_acq', 'date', 'dither_acq')
 
+    t_ccd = AliasAttribute()  # Maps t_ccd to t_ccd_acq base attribute
+    dither = AliasAttribute()  # .. and likewise.
+    include_ids = AliasAttribute()
+    include_halfws = AliasAttribute()
+    exclude_ids = AliasAttribute()
+
     p_man_errs = MetaAttribute(is_kwarg=False)
     cand_acqs = MetaAttribute(is_kwarg=False)
     p_safe = MetaAttribute(is_kwarg=False)
@@ -174,11 +180,6 @@ class AcqTable(ACACatalogTable):
         out['halfw'] = np.full(fill_value=0, shape=(0,), dtype=np.int64)
         return out
 
-    t_ccd = AliasAttribute()
-    dither = AliasAttribute()
-    include_ids = AliasAttribute()
-    include_halfws = AliasAttribute()
-    exclude_ids = AliasAttribute()
 
     @property
     def fid_set(self):

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -156,6 +156,17 @@ class ACATable(ACACatalogTable):
     # catalog in the ACATable meta.
     starcheck_catalog = MetaAttribute(is_kwarg=False)
 
+    @property
+    def t_ccd(self):
+        if self.t_ccd_acq != self.t_ccd_guide:
+            raise ValueError('t_ccd attribute is ambiguous: acq and guide t_ccd are different')
+        return self.t_ccd_guide
+
+    @t_ccd.setter
+    def t_ccd(self, value):
+        self.t_ccd_guide = value
+        self.t_ccd_acq = value
+
     @classmethod
     def empty(cls):
         out = super().empty()

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -192,6 +192,8 @@ class ACATable(ACACatalogTable):
 
     @property
     def t_ccd(self):
+        # For top-level ACATable object use the guide temperature, which is always
+        # greater than or equal to the acq temperature.
         return self.t_ccd_guide
 
     @t_ccd.setter

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -10,6 +10,9 @@ from .acq import get_acq_catalog, AcqTable
 from .fid import get_fid_catalog, FidTable
 from . import characteristics_acq as ACQ
 from . import characteristics as ACA
+from . import test as test_from_init
+
+VERSION = test_from_init(get_version=True)
 
 
 def get_aca_catalog(obsid=0, **kwargs):
@@ -176,6 +179,7 @@ class ACATable(ACACatalogTable):
     """
     optimize = MetaAttribute(default=True)
     call_args = MetaAttribute(default={})
+    version = MetaAttribute()
 
     # For validation with get_aca_catalog(obsid), store the starcheck
     # catalog in the ACATable meta.
@@ -233,6 +237,7 @@ class ACATable(ACACatalogTable):
 
         self.t_ccd_eff_acq = get_effective_t_ccd(self.t_ccd_acq)
         self.t_ccd_eff_guide = get_effective_t_ccd(self.t_ccd_guide)
+        self.version = VERSION
 
 
     def get_review_table(self):

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -9,6 +9,7 @@ from .guide import get_guide_catalog, GuideTable
 from .acq import get_acq_catalog, AcqTable
 from .fid import get_fid_catalog, FidTable
 from . import characteristics_acq as ACQ
+from . import characteristics as ACA
 
 
 def get_aca_catalog(obsid=0, **kwargs):
@@ -96,6 +97,14 @@ def _get_aca_catalog(**kwargs):
     aca.call_args = kwargs.copy()
     aca.set_attrs_from_kwargs(**kwargs)
 
+    # Override t_ccd related inputs with effective temperatures for downstream
+    # action by AcqTable, GuideTable, FidTable.  See set_attrs_from_kwargs()
+    # method for more details.
+    if 't_ccd' in kwargs:
+        del kwargs['t_ccd']
+    kwargs['t_ccd_acq'] = aca.t_ccd_eff_acq
+    kwargs['t_ccd_guide'] = aca.t_ccd_eff_guide
+
     # Get stars (typically from AGASC) and do not filter for stars near
     # the ACA FOV.  This leaves the full radial selection available for
     # later roll optimization.  Use aca.stars or aca.acqs.stars from here.
@@ -144,6 +153,22 @@ def _get_aca_catalog(**kwargs):
     return aca
 
 
+def get_effective_t_ccd(t_ccd):
+    """Return the effective T_ccd used for selection and catalog evaluation.
+
+    For details see Dynamic ACA limits in baby steps section in:
+    https://occweb.cfa.harvard.edu/twiki/bin/view/Aspect/StarWorkingGroupMeeting2019x02x13
+
+    :param t_ccd:
+    :return:
+    """
+    t_limit = ACA.aca_t_ccd_planning_limit
+    if t_ccd > t_limit:
+        return t_ccd + 1 + (t_ccd - t_limit)
+    else:
+        return t_ccd
+
+
 class ACATable(ACACatalogTable):
     """Container ACACatalogTable class that has merged guide / acq / fid catalogs
     as attributes and other methods relevant to the merged catalog.
@@ -155,6 +180,11 @@ class ACATable(ACACatalogTable):
     # For validation with get_aca_catalog(obsid), store the starcheck
     # catalog in the ACATable meta.
     starcheck_catalog = MetaAttribute(is_kwarg=False)
+
+    # Effective T_ccd used for dynamic ACA limits (see updates_for_t_ccd_effective()
+    # method below).
+    t_ccd_eff_acq = MetaAttribute(is_kwarg=False)
+    t_ccd_eff_guide = MetaAttribute(is_kwarg=False)
 
     @property
     def t_ccd(self):
@@ -180,6 +210,30 @@ class ACATable(ACACatalogTable):
         return int(self.acqs.thumbs_up &
                    self.fids.thumbs_up &
                    self.guides.thumbs_up)
+
+    def set_attrs_from_kwargs(self, **kwargs):
+        """Set object attributes from kwargs.
+
+        After calling the base class method which does all the real work, then
+        compute the effective T_ccd temperatures.
+
+        In this ACATable object:
+        - t_ccd_eff_{acq,guide} are the effective T_ccd values which are adjusted
+          if the actual t_ccd{acq,guide} values are above ACA.aca_t_ccd_planning_limit.
+        - t_ccd_{acq,guide} are the actual (or predicted) values from the call
+
+        The downstream AcqTable, GuideTable, and FidTable are initialized with the
+        *effective* values as t_ccd.  Those classes do not have the concept of effective
+        temperature.
+
+        :param kwargs: dict of input kwargs
+        :return: dict
+        """
+        super().set_attrs_from_kwargs(**kwargs)
+
+        self.t_ccd_eff_acq = get_effective_t_ccd(self.t_ccd_acq)
+        self.t_ccd_eff_guide = get_effective_t_ccd(self.t_ccd_guide)
+
 
     def get_review_table(self):
         """Get ACAReviewTable object based on self.

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -192,8 +192,6 @@ class ACATable(ACACatalogTable):
 
     @property
     def t_ccd(self):
-        if self.t_ccd_acq != self.t_ccd_guide:
-            raise ValueError('t_ccd attribute is ambiguous: acq and guide t_ccd are different')
         return self.t_ccd_guide
 
     @t_ccd.setter

--- a/proseco/characteristics.py
+++ b/proseco/characteristics.py
@@ -25,6 +25,9 @@ max_ccd_col = CCD['col_max'] - CCD['col_pad']  # Max allow col for stars (SOURCE
 col_spoiler_mag_diff = 4.5
 col_spoiler_pix_sep = 10  # pixels
 
+# ACA T_ccd planning limit (degC)
+aca_t_ccd_planning_limit = -9.5
+
 # Dark current that corresponds to a 5.0 mag star in a single pixel.  Apply
 # this value to the region specified by bad_pixels.
 bad_pixel_dark_current = 700_000

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -692,11 +692,12 @@ class ACACatalogTable(BaseCatalogTable):
 
     @property
     def t_ccd(self):
-        return self.t_ccd_guide
+        # Subclasses must implement.
+        raise NotImplementedError()
 
     @t_ccd.setter
     def t_ccd(self, value):
-        self.t_ccd_guide = value
+        raise NotImplementedError()
 
     @classmethod
     def empty(cls):

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -108,6 +108,15 @@ class FidTable(ACACatalogTable):
         self._acqs = weakref.ref(val)
 
     @property
+    def t_ccd(self):
+        # For fids use the guide CCD temperature
+        return self.t_ccd_guide
+
+    @t_ccd.setter
+    def t_ccd(self, value):
+        self.t_ccd_guide = value
+
+    @property
     def thumbs_up(self):
         if self.n_fid == 0:
             out = 1

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -94,8 +94,8 @@ class GuideTable(ACACatalogTable):
         reject_info = self.reject_info
         reject_info.append(reject)
 
-    t_ccd = AliasAttribute()
-    dither = AliasAttribute()
+    t_ccd = AliasAttribute()  # Maps t_ccd to t_ccd_guide attribute from base class
+    dither = AliasAttribute()  # .. and likewise.
     include_ids = AliasAttribute()
     exclude_ids = AliasAttribute()
 

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -314,7 +314,6 @@ def test_t_ccd_effective_acq_guide(t_ccd_case):
     below the planning limit.
 
     """
-    dark = DARK40.copy()
     stars = StarsTable.empty()
     stars.add_fake_constellation(mag=8.0, n_stars=8)
 
@@ -325,13 +324,8 @@ def test_t_ccd_effective_acq_guide(t_ccd_case):
     t_ccd_acq = t_limit + t_offset
     t_ccd_guide = t_ccd_acq - 0.1
 
-    kwargs = mod_std_info(stars=stars, dark=dark,
-                          t_ccd_acq=t_ccd_acq, t_ccd_guide=t_ccd_guide)
+    kwargs = mod_std_info(stars=stars, t_ccd_acq=t_ccd_acq, t_ccd_guide=t_ccd_guide)
     aca = get_aca_catalog(**kwargs)
-
-    with pytest.raises(ValueError):
-        # Cannot access this attribute if acq and guide temps are different
-        aca.t_ccd
 
     assert np.isclose(aca.t_ccd_acq, t_ccd_acq)
     assert np.isclose(aca.t_ccd_guide, t_ccd_guide)

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -13,8 +13,8 @@ import numpy as np
 import mica.starcheck
 
 from .test_common import STD_INFO, mod_std_info, DARK40, OBS_INFO
-from ..core import StarsTable, ACACatalogTable
-from ..catalog import get_aca_catalog
+from ..core import StarsTable
+from ..catalog import get_aca_catalog, ACATable
 from ..fid import get_fid_catalog
 from .. import characteristics as ACA
 
@@ -167,7 +167,7 @@ def test_big_dither_from_mica_starcheck():
     Test code that infers dither_acq and dither_guide for a big-dither
     observation like 20168.
     """
-    aca = ACACatalogTable()
+    aca = ACATable()
     aca.set_attrs_from_kwargs(obsid=20168)
 
     assert aca.detector == 'HRC-S'


### PR DESCRIPTION
This adds two top-level attributes `t_ccd_eff_acq` and `t_ccd_eff_guide` to capture the effective T_ccd that gets used in downstream processing.  It leaves `t_ccd_acq` and `t_ccd_guide` as the user-supplied values.

In the `acqs` and `guides` and `fids` objects, `t_ccd_acq/guide` is always the **effective** temperature.  The idea is that those "low-level" objects don't need to fuss about this detail of how we implement dynamic limits.  These objects just do their job of selecting stars for a given CCD temperature.  This is all illustrated in the tests.

This also adds a `version` attribute to ACATable.
Closes #257 