### PR TITLE
Read AGASC supplement and add to bad_stars_set if available

### DIFF
--- a/proseco/characteristics.py
+++ b/proseco/characteristics.py
@@ -1,3 +1,8 @@
+import os
+import warnings
+from pathlib import Path
+from astropy.table import Table
+
 CCD = {'row_min': -512.0,
        'row_max': 512.0,
        'col_min': -512.0,
@@ -74,3 +79,11 @@ bad_star_set = set([36178592,
                    1196953168,
                    1197635184,
                    1158290496])
+
+# Add in entries from the AGASC supplement file, if possible, warn otherwise
+agasc_supplement_file = Path(os.environ['SKA']) / 'data' / 'agasc' / 'agasc_supplement.h5'
+if agasc_supplement_file.exists():
+    bad_star_table = Table.read(str(agasc_supplement_file), path='bad')
+    bad_star_set.update(set(bad_star_table['agasc_id'].tolist()))
+else:
+    warnings.warn(f'Unable to find {agasc_supplement_file}, using limited bad star set')

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -10,6 +10,7 @@ from ..core import (ACABox, get_kwargs_from_starcheck_text, calc_spoiler_impact,
                     StarsTable)
 from ..acq import AcqTable
 from ..guide import GuideTable
+from ..characteristics import bad_star_set
 
 
 def test_agasc_1p7():
@@ -25,6 +26,13 @@ def test_agasc_1p7():
     star = agasc.get_star(611193056)
     assert star['RSV3'] == 0
     assert star['RSV2'] == -9999
+
+
+def test_agasc_supplement():
+    assert len(bad_star_set) > 3300
+    assert 36178592 in bad_star_set  # From original starcheck list
+    assert 658160 in bad_star_set
+    assert 1248994952 in bad_star_set
 
 
 def test_box_init():


### PR DESCRIPTION
Closes #261.

Will open another issue to capture the idea of getting mags from a history file, for now descoping 261 to just be bad stars. To do:

- [x] Tests