### PR TITLE
Reduce allowed position error from 3.0 to 1.25 arcsec

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -354,7 +354,7 @@ class GuideTable(ACACatalogTable):
               (stars['mag_err'] < 1.0) &  # Mag err < 1.0 mag
               (stars['ASPQ1'] < 20) &  # Less than 1 arcsec offset from nearby spoiler
               (stars['ASPQ2'] == 0) &  # Proper motion less than 0.5 arcsec/yr
-              (stars['POS_ERR'] < 3000) &  # Position error < 3.0 arcsec
+              (stars['POS_ERR'] < 1250) &  # Position error < 1.25 arcsec
               ((stars['VAR'] == -9999) | (stars['VAR'] == 5))  # Not known to vary > 0.2 mag
               )
         return ok


### PR DESCRIPTION
This cuts about 90 out of 432000 stars that were allowed in with the 3.0 arcsec limit.  Systematic positional offsets can lead to roll errors and potential failed maneuver.

Closes #242.

In that issue a number of 1.0 arcsec was discussed, but I think it is OK to expand to 1.25 arcsec and reduce the number of stars excluded from about 800 to about 90.

This passes unit tests.  Was not planning any separate validation. 