### PR TITLE
Make copy, deepcopy, pickle, ACATable init all give consistent expected results

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -141,12 +141,23 @@ class AcqTable(ACACatalogTable):
 
         """
         super().__setstate__(state)
+        self.set_cand_acqs_probs_weakref()
 
-        # This could be a cand_acqs table or acqs table, so check if
-        # ``cand_acqs`` has something, and if so then create the weakref in
-        # each of the AcqProbs objects stored in the ``probs`` column.  TO DO:
-        # make two separate classes AcqTable and CandAcqTable to avoid this
-        # contextual hack.
+    def copy(self, copy_data=True):
+        out = super().copy(copy_data)
+        out.set_cand_acqs_probs_weakref()
+        return out
+
+    def set_cand_acqs_probs_weakref(self):
+        """
+        This could be a cand_acqs table or acqs table, so check if
+        ``cand_acqs`` has something, and if so then create the weakref in
+        each of the AcqProbs objects stored in the ``probs`` column.  TO DO:
+        make two separate classes AcqTable and CandAcqTable to avoid this
+        contextual hack.
+
+        :return: None
+        """
         if self.cand_acqs is not None:
             for probs in self.cand_acqs['probs']:
                 probs.acqs = weakref.ref(self)


### PR DESCRIPTION
This should make the proseco table objects behave in a more expected way with regard to copying operations that should just work.

Probably would have prevented https://github.com/sot/sparkles/issues/59.

FYI both copy.copy and copy.deepcopy end up calling the new `copy()` here.