### PR TITLE
Always cast 'att' attribute into Quat object

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -332,6 +332,11 @@ class MetaAttribute:
         return (f'<{self.__class__.__name__} name={self.name} default={self.default} '
                 f'pickle={self.pickle}>')
 
+class QuatMetaAttribute(MetaAttribute):
+    def __set__(self, instance, value):
+        if not isinstance(value, Quat):
+            value = Quat(value)
+        instance.meta[self.name] = value
 
 class IntMetaAttribute(MetaAttribute):
     def __set__(self, instance, value):
@@ -524,7 +529,7 @@ class ACACatalogTable(BaseCatalogTable):
     required_attrs = ('dither_acq', 'dither_guide', 'date')
 
     obsid = MetaAttribute(default=0)
-    att = MetaAttribute()
+    att = QuatMetaAttribute()
     n_acq = MetaAttribute(default=8)
     n_guide = MetaAttribute()
     n_fid = MetaAttribute(default=3)
@@ -965,7 +970,7 @@ class StarsTable(BaseCatalogTable):
     - empty() : empty catalog, then use add_* methods to add stars
 
     """
-    att = MetaAttribute()
+    att = QuatMetaAttribute()
 
     # StarsTable attributes, gets set in MetaAttribute or AliasAttribute
     allowed_kwargs = set()

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from pathlib import Path
 
+from Quaternion import Quat
 from chandra_aca.aca_image import AcaPsfLibrary
 from chandra_aca.transform import mag_to_count_rate, yagzag_to_pixels
 
@@ -558,6 +559,8 @@ def test_make_report(tmpdir):
         val2 = getattr(acqs2, attr)
         if isinstance(val, float):
             assert np.isclose(val, val2)
+        elif isinstance(val, Quat):
+            assert np.allclose(val.q, val2.q)
         else:
             assert val == val2
 

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -2,6 +2,7 @@
 import copy
 
 import matplotlib
+from Quaternion import Quat
 
 matplotlib.use('agg')
 
@@ -217,6 +218,8 @@ def test_pickle():
             val2 = getattr(obj2, attr)
             if isinstance(val, float):
                 assert np.isclose(val, val2)
+            elif isinstance(val, Quat):
+                assert np.allclose(val.q, val2.q)
             else:
                 assert val == val2
 
@@ -706,5 +709,5 @@ def test_force_catalog_from_starcheck():
     assert aca['halfw'].tolist() == [25, 25, 25,
                                      120, 160, 160, 120, 160,
                                      120, 120, 120]
-    assert np.allclose(aca.att, [358.341787, -12.949882, 276.997597], rtol=0, atol=1e-6)
+    assert np.allclose(aca.att.equatorial, [358.341787, -12.949882, 276.997597], rtol=0, atol=1e-6)
     assert np.allclose(aca.acqs.man_angle, 89.16)

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -255,7 +255,7 @@ def test_pickle_stars():
     att = [1, 2, 3]
     stars = StarsTable.from_agasc(att)
     stars2 = pickle.loads(pickle.dumps(stars))
-    assert stars2.att == att
+    assert np.allclose(stars2.att.equatorial, att)
     assert stars2.colnames == stars.colnames
     assert repr(stars) == repr(stars2)
 

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 import numpy as np
 import itertools
+
+from Quaternion import Quat
 from astropy.table import Table
 import pytest
 
@@ -577,5 +579,7 @@ def test_make_report_guide(tmpdir):
         val2 = getattr(guides2, attr)
         if isinstance(val, float):
             assert np.isclose(val, val2)
+        elif isinstance(val, Quat):
+            assert np.allclose(val.q, val2.q)
         else:
             assert val == val2


### PR DESCRIPTION
Leaving the `att` (attitude) attribute as whatever the user supplied instead of casting to Quat makes life difficult for downstream code.  This fixes that and with this in place one can be sure that `aca.att` is a `Quat`.

This passes tests.  Sparkles passes tests (except for the known fail).