### PR TITLE
Fix guide and acq report templates after #281

### DIFF
--- a/proseco/index_template_acq.html
+++ b/proseco/index_template_acq.html
@@ -40,12 +40,13 @@ table.table-striped td {
 <h1> Obsid {{obsid}} at {{date}}</h1>
 
 <table class="table-striped">
-  <tr>  <td> <b>ra</b> </td> <td> {{ att[0] }} </td> </tr>
-  <tr>  <td> <b>dec</b> </td> <td> {{ att[1] }} </td> </tr>
-  <tr>  <td> <b>roll</b> </td> <td> {{ att[2] }} </td> </tr>
-  <tr>  <td> <b>t_ccd</b> </td> <td> {{ t_ccd_acq }} C</td> </tr>
-  <tr>  <td> <b>man angle</b> </td> <td> {{ man_angle }} deg</td> </tr>
-  <tr>  <td> <b>dither (y, z)</b> </td> <td> {{ dither_acq.y }}, {{ dither_acq.z }} arcsec</td> </tr>
+  <tr>  <td> <b>ra</b> </td> <td> {{ '%.5f' | format(att.ra) }} </td> </tr>
+  <tr>  <td> <b>dec</b> </td> <td> {{ '%.5f' | format(att.dec) }} </td> </tr>
+  <tr>  <td> <b>roll</b> </td> <td> {{ '%.5f' | format(att.roll) }} </td> </tr>
+  <tr>  <td> <b>t_ccd</b> </td> <td> {{ '%.2f' | format(t_ccd_acq) }} C</td> </tr>
+  <tr>  <td> <b>man angle</b> </td> <td> {{ '%.2f' | format(man_angle) }} deg</td> </tr>
+  <tr>  <td> <b>dither (y, z)</b> </td> <td> {{ dither_acq.y | round(2) }},
+    {{ dither_acq.z | round(2) }} arcsec</td> </tr>
   <tr>  <td> <b>n_acq</b> </td> <td> {{ n_acq }} </td> </tr>
   {% if include_ids %} <tr>  <td> <b>include_ids</b> </td> <td> {{ include_ids }} </td> </tr> {% endif %}
   {% if include_halfws %} <tr>  <td> <b>include_halfws</b> </td> <td> {{ include_halfws }} arcsec </td> </tr> {% endif %}

--- a/proseco/index_template_guide.html
+++ b/proseco/index_template_guide.html
@@ -40,11 +40,12 @@ table.table-striped td {
 <h1> Obsid {{obsid}} at {{date}}</h1>
 
 <table class="table-striped">
-  <tr>  <td> <b>ra</b> </td> <td> {{ att[0] }} </td> </tr>
-  <tr>  <td> <b>dec</b> </td> <td> {{ att[1] }} </td> </tr>
-  <tr>  <td> <b>roll</b> </td> <td> {{ att[2] }} </td> </tr>
-  <tr>  <td> <b>t_ccd</b> </td> <td> {{ t_ccd_guide }} C</td> </tr>
-  <tr>  <td> <b>dither (y, z)</b> </td> <td> {{ dither_guide.y }}, {{ dither_guide.z }} arcsec</td> </tr>
+  <tr>  <td> <b>ra</b> </td> <td> {{ '%.5f' | format(att.ra) }} </td> </tr>
+  <tr>  <td> <b>dec</b> </td> <td> {{ '%.5f' | format(att.dec) }} </td> </tr>
+  <tr>  <td> <b>roll</b> </td> <td> {{ '%.5f' | format(att.roll) }} </td> </tr>
+  <tr>  <td> <b>t_ccd</b> </td> <td> {{ '%.2f' | format(t_ccd_guide) }} C</td> </tr>
+  <tr>  <td> <b>dither (y, z)</b> </td> <td> {{ dither_guide.y | round(2) }},
+    {{ dither_guide.z | round(2) }} arcsec</td> </tr>
   <tr>  <td> <b>n_guide</b> </td> <td> {{ n_guide }} </td> </tr>
   {% if include_ids %} <tr>  <td> <b>include_ids</b> </td> <td> {{ include_ids }} </td> </tr> {% endif %}
   {% if exclude_ids %} <tr>  <td> <b>exclude_ids</b> </td> <td> {{ exclude_ids }} </td> </tr> {% endif %}


### PR DESCRIPTION
Oops.  But the report templates were just fragile before and depended on user supplying attitude as a list of [ra, dec, roll].  This also moves the formatting into the template where it belongs.