### PR TITLE
Remove the AcqProbs weakref to acqs

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -1202,7 +1202,7 @@ class AcqProbs:
     def p_on_ccd(self, man_err):
         return self._p_on_ccd[man_err]
 
-    def p_brightest(self, box_size, man_err):
+    def p_brightest(self, box_size, man_err, acqs):
         return self._p_brightest[box_size, man_err]
 
     def p_acq_model(self, box_size):
@@ -1213,7 +1213,7 @@ class AcqProbs:
         try:
             return self._p_acqs[box_size, man_err, fid_set]
         except KeyError:
-            p_acq = (self.p_brightest(box_size, man_err) *
+            p_acq = (self.p_brightest(box_size, man_err, acqs) *
                      self.p_acq_model(box_size) *
                      self.p_on_ccd(man_err) *
                      self.p_fid_spoiler(box_size, acqs))

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -73,7 +73,6 @@ def get_acq_catalog(obsid=0, **kwargs):
                                 for man_err in ACQ.man_errs])
 
     acqs.cand_acqs = acqs.get_acq_candidates(acqs.stars)
-    acqs.cand_acqs.p_man_errs = acqs.p_man_errs
 
     # Fill in the entire acq['probs'].p_acqs table (which is actual a dict of keyed by
     # (box_size, man_err) tuples).

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -1199,8 +1199,6 @@ class AcqProbs:
         self._p_fid_spoiler = {}
         self._p_fid_id_spoiler = {}
 
-        self.acqs = weakref.ref(acqs)
-
         # Convert table row to plain dict for persistence
         self.acq = {key: acq[key] for key in ('yang', 'zang')}
 

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -351,7 +351,7 @@ class ACATable(ACACatalogTable):
                 else:
                     # Re-optimize the catalog with the fid set selected and get new probs.
                     acqs.optimize_catalog()
-                    acqs.update_p_acq_column(acqs)  # Needed for get_log_p_2_or_fewer
+                    acqs.update_p_acq_column()  # Needed for get_log_p_2_or_fewer
 
                 # Store optimization results
                 fid_set['P2'] = -acqs.get_log_p_2_or_fewer()

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -351,7 +351,7 @@ class ACATable(ACACatalogTable):
                 else:
                     # Re-optimize the catalog with the fid set selected and get new probs.
                     acqs.optimize_catalog()
-                    acqs.update_p_acq_column()  # Needed for get_log_p_2_or_fewer
+                    acqs.update_p_acq_column(acqs)  # Needed for get_log_p_2_or_fewer
 
                 # Store optimization results
                 fid_set['P2'] = -acqs.get_log_p_2_or_fewer()

--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -38,6 +38,7 @@ def get_p_acqs_table(acq, p_name):
         of ``man_err`` and ``dither``)
     - ``p_acqs``: product of the above three
     """
+    acqs = acq._table
     man_errs = ACQ.p_man_errs['man_err_hi']
     box_sizes = sorted(ACQ.box_sizes)
     names = [r'box \ man_err'] + [f'{man_err}"' for man_err in man_errs]
@@ -45,7 +46,7 @@ def get_p_acqs_table(acq, p_name):
     cols[r'box \ man_err'] = [f'{box_size}"' for box_size in box_sizes]
     for man_err in man_errs:
         name = f'{man_err}"'
-        cols[name] = [round(getattr(acq['probs'], p_name)(box_size, man_err), 3)
+        cols[name] = [round(getattr(acq['probs'], p_name)(box_size, man_err, acqs), 3)
                       for box_size in box_sizes]
 
     return table_to_html(Table(cols, names=names))

--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -26,7 +26,7 @@ ACQ_COLS = ['idx', 'slot', 'id', 'yang', 'zang', 'row', 'col',
             'mag', 'mag_err', 'color', 'halfw', 'p_acq']
 
 
-def get_p_acqs_table(acq, p_name):
+def get_p_acqs_table(acqs, acq, p_name):
     """
     Make HTML tables for an acq star for the following:
 
@@ -34,7 +34,6 @@ def get_p_acqs_table(acq, p_name):
         of ``box_size`` and ``man_err``)
     - ``p_acqs``: product of all probability bits
     """
-    acqs = acq._table
     man_errs = ACQ.p_man_errs['man_err_hi']
     box_sizes = sorted(ACQ.box_sizes)
     names = [r'box \ man_err'] + [f'{man_err}"' for man_err in man_errs]
@@ -195,8 +194,8 @@ def make_acq_star_details_report(acqs, cand_acqs, events, context, obsdir):
                            .format(aq['id']) for aq in acq_table]
         cca['acq_table'] = table_to_html(acq_table)
 
-        cca['p_brightest_table'] = get_p_acqs_table(acq, 'p_brightest')
-        cca['p_acqs_table'] = get_p_acqs_table(acq, 'p_acqs')
+        cca['p_brightest_table'] = get_p_acqs_table(acqs, acq, 'p_brightest')
+        cca['p_acqs_table'] = get_p_acqs_table(acqs, acq, 'p_acqs')
         cca['p_acq_model_table'] = get_p_acq_model_table(acq)
         cca['p_on_ccd_table'] = get_p_on_ccd_table(acq)
 

--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -32,11 +32,7 @@ def get_p_acqs_table(acq, p_name):
 
     - ``p_brightest``: probability this star is the brightest in box (function
         of ``box_size`` and ``man_err``)
-    - ``p_acq_model``: probability of acquisition from the chandra_aca model
-        (function of ``box_size``)
-    - ``p_on_ccd``: probability star is on the usable part of the CCD (function
-        of ``man_err`` and ``dither``)
-    - ``p_acqs``: product of the above three
+    - ``p_acqs``: product of all probability bits
     """
     acqs = acq._table
     man_errs = ACQ.p_man_errs['man_err_hi']

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -787,8 +787,8 @@ def test_acq_fid_catalog_probs_low_level():
     acq = acqs.get_id(2)
     p0 = acq['probs']
 
-    assert p0.p_fid_id_spoiler(box_size_thresh - 1, fid_id=2) == 1.0  # OK
-    assert p0.p_fid_id_spoiler(box_size_thresh + 1, fid_id=2) == 0.0  # spoiled
+    assert p0.p_fid_id_spoiler(box_size_thresh - 1, fid_id=2, acqs=acqs) == 1.0  # OK
+    assert p0.p_fid_id_spoiler(box_size_thresh + 1, fid_id=2, acqs=acqs) == 0.0  # spoiled
 
     # Caching of values
     assert p0._p_fid_id_spoiler == {(box_size_thresh - 1, 2): 1.0,
@@ -797,8 +797,8 @@ def test_acq_fid_catalog_probs_low_level():
     # With fid_set = (), the probability multiplier for any fid in the fid set
     # spoiling this star is 1.0, i.e. no fids spoil this star (since there
     # are no fids).
-    assert p0.p_fid_spoiler(box_size_thresh - 1) == 1.0
-    assert p0.p_fid_spoiler(box_size_thresh + 1) == 1.0
+    assert p0.p_fid_spoiler(box_size_thresh - 1, acqs) == 1.0
+    assert p0.p_fid_spoiler(box_size_thresh + 1, acqs) == 1.0
 
     # Now change the fid set to include ones (in particular fid_id=2) that
     # spoils an acq star.  This makes the p_safe value much worse.
@@ -810,8 +810,8 @@ def test_acq_fid_catalog_probs_low_level():
     # With fid_set = (1, 2, 4), the probability multiplier for catalog
     # ids 2 and 4 are spoiled.  This test checks for star id=2 (which is
     # near fid_id=2).
-    assert p0.p_fid_spoiler(box_size_thresh - 1) == 1.0
-    assert p0.p_fid_spoiler(box_size_thresh + 1) == 0.0
+    assert p0.p_fid_spoiler(box_size_thresh - 1, acqs) == 1.0
+    assert p0.p_fid_spoiler(box_size_thresh + 1, acqs) == 0.0
 
     # Reverting fid set also revert the p_safe value.  Note the (1, 3, 4)
     # set does not spoil an acq star.
@@ -827,10 +827,10 @@ def test_acq_fid_catalog_probs_low_level():
                 continue  # p_acq always zero in this case, see AcqProbs.__init__()
 
             acqs.fid_set = ()
-            p_acq0 = acq['probs'].p_acqs(box_size, man_err)
+            p_acq0 = acq['probs'].p_acqs(box_size, man_err, acqs)
 
             acqs.fid_set = (2, 3, 4)
-            p_acq1 = acq['probs'].p_acqs(box_size, man_err)
+            p_acq1 = acq['probs'].p_acqs(box_size, man_err, acqs)
 
             if box_size > box_size_thresh:
                 # Box includes spoiler so p_acq1 is 0

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -260,15 +260,6 @@ def test_copy_deepcopy_pickle():
             assert repr(val) == repr(val2)
             assert val is not val2
 
-    for probs in aca2.acqs.cand_acqs['probs']:
-        assert probs.acqs() is aca2.acqs
-
-    if func is not f4:
-        # Try to make this work but not a high priority
-        acqs2 = func(aca.acqs)
-        for probs in acqs2.cand_acqs['probs']:
-            assert probs.acqs() is acqs2
-
 
 def test_big_sim_offset():
     """


### PR DESCRIPTION
This gets rid of the `AcqProbs.acqs` weakref to the acqs table. All tests are passing.