### PR TITLE
Use np.ndarray instead of ACAImage for dark map

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -13,7 +13,7 @@ from astropy.table import Table, Column
 
 from chandra_aca.transform import (yagzag_to_pixels, pixels_to_yagzag,
                                    count_rate_to_mag, mag_to_count_rate)
-from chandra_aca.aca_image import ACAImage, AcaPsfLibrary
+from chandra_aca.aca_image import AcaPsfLibrary
 from Ska.quatutil import radec2yagzag, yagzag2radec
 import agasc
 from Quaternion import Quat
@@ -565,21 +565,18 @@ class ACACatalogTable(BaseCatalogTable):
         self.log(f'Getting dark cal image at date={self.date} t_ccd={self.t_ccd:.1f}')
         self.dark = get_dark_cal_image(date=self.date, select='before',
                                        t_ccd_ref=self.t_ccd,
-                                       aca_image=True)
+                                       aca_image=False)
         return self._dark
 
     @dark.setter
     def dark(self, value):
-        if not isinstance(value, ACAImage):
-            assert value.shape == (1024, 1024)
-            value = ACAImage(value, row0=-512, col0=-512, copy=False)
-
+        assert value.shape == (1024, 1024)
         self._dark = value
 
         # Set pixel regions from ACA.bad_pixels to have acqs.dark=700000 (5.0 mag
         # star) per pixel.
         for r0, r1, c0, c1 in ACA.bad_pixels:
-            self._dark.aca[r0:r1 + 1, c0:c1 + 1] = ACA.bad_pixel_dark_current
+            self._dark[r0 + 512:r1 + 513, c0 + 512:c1 + 513] = ACA.bad_pixel_dark_current
 
     def set_attrs_from_kwargs(self, **kwargs):
         for name, val in kwargs.items():

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -358,7 +358,7 @@ class FidTable(ACACatalogTable):
         c0 = int(fid['col'] - dp)
         r1 = int(fid['row'] + dp) + 1
         c1 = int(fid['col'] + dp) + 1
-        dark = self.dark.aca[r0:r1, c0:c1]
+        dark = self.dark[r0 + 512:r1 + 512, c0 + 512:c1 + 512]
 
         bad = dark > FID.hot_pixel_spoiler_limit
         if np.any(bad):

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -751,7 +751,7 @@ def get_imposter_mags(cand_stars, dark, dither):
     for cand in cand_stars:
         rminus, rplus = get_ax_range(cand['row'], row_extent)
         cminus, cplus = get_ax_range(cand['col'], col_extent)
-        pix = np.array(dark.aca[rminus:rplus, cminus:cplus])
+        pix = np.array(dark[rminus + 512:rplus + 512, cminus + 512:cplus + 512])
         pixmax = 0
         max_r = None
         max_c = None

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -776,7 +776,7 @@ def test_acq_fid_catalog_probs_low_level():
     aca = get_aca_catalog(**kwargs)
     acqs = aca.acqs
 
-    assert np.all(acqs.dark.aca[-512:0, -512:0] == 40)
+    assert np.all(acqs.dark[0:512, 0:512] == 40)
 
     # Initial fid set is empty () and we check baseline p_safe
     assert acqs.fid_set == ()

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -405,7 +405,7 @@ def test_bad_pixel_dark_current():
     aca = get_aca_catalog(**kwargs)
 
     # Make sure bad pixels have expected value
-    assert np.all(aca.acqs.dark.aca[-245:0, 454] == ACA.bad_pixel_dark_current)
+    assert np.all(aca.acqs.dark[-245 + 512:512, 454 + 512] == ACA.bad_pixel_dark_current)
 
     exp_ids = [2, 100, 101, 102, 103]
     assert sorted(aca.guides['id']) == exp_ids

--- a/proseco/tests/test_common.py
+++ b/proseco/tests/test_common.py
@@ -20,7 +20,7 @@ def mod_std_info(**kwargs):
 
 
 # Flat dark current map
-DARK40 = ACAImage(np.full(shape=(1024, 1024), fill_value=40), row0=-512, col0=-512)
+DARK40 = np.full(shape=(1024, 1024), fill_value=40)
 
 
 # Parameters for test cases (to avoid starcheck.db3 dependence)

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -211,7 +211,7 @@ def test_fid_hot_pixel_reject():
         fid = FIDS.cand_fids.get_id(fid_id)
         r = int(round(fid['row'] + off))
         c = int(round(fid['col'] + off))
-        dark.aca[r, c] = dc
+        dark[r + 512, c + 512] = dc
 
     fids = get_fid_catalog(stars=StarsTable.empty(), dark=dark, **STD_INFO)
     assert fids['id'].tolist() == [2, 3, 6]

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -340,15 +340,15 @@ def test_pix_spoiler(case):
     stars = StarsTable.empty()
     stars.add_fake_star(row=0, col=0, mag=7.0, id=1, ASPQ1=0)
     stars.add_fake_constellation(n_stars=4)
-    dark = ACAImage(np.zeros((1024, 1024)), row0=-512, col0=-512)
+    dark = np.zeros((1024, 1024))
     pix_config = {'att': (0, 0, 0),
                   'date': '2018:001',
                   't_ccd': -10,
                   'n_guide': 5,
                   'stars': stars}
     # Use the "case" to try to spoil the first star with a bad pixel
-    dark.aca[case['offset_row'] + int(stars[0]['row']),
-             case['offset_col'] + int(stars[0]['col'])] = mag_to_count_rate(stars[0]['mag'])
+    dark[case['offset_row'] + int(stars[0]['row']) + 512,
+         case['offset_col'] + int(stars[0]['col']) + 512] = mag_to_count_rate(stars[0]['mag'])
     selected = get_guide_catalog(**pix_config, dither=case['dither'], dark=dark)
     assert (1 not in selected['id']) == case['spoils']
 


### PR DESCRIPTION
The `ACAImage` class is nice and convenient, but sadly even a few lines of pure Python ends up being really slow for array item access.  The change in this PR makes the run time about 75-80% of what it is with current master.  So for 30 obsids with a current average time of 1.1 sec, that would shave off 6-7 seconds out of 33.0.