### PR TITLE
Fix bug in setting stars attribute in reporting

### DIFF
--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -317,8 +317,9 @@ def make_report(obsid, rootdir='.'):
     context['include_halfws'] = ", ".join([str(val) for val in acqs.include_halfws])
     context['exclude_ids'] = ", ".join([str(val) for val in acqs.exclude_ids])
 
-    # Get information that is not stored in the acqs pickle for space reasons
-    acqs.stars = StarsTable.from_agasc(acqs.att, date=acqs.date)
+    # Get stars if not already set (e.g. if acqs is coming from a pickle).  If
+    # acqs.stars is already correctly defined this does nothing.
+    acqs.set_stars()
 
     events = make_events(acqs)
     context['events'] = events

--- a/proseco/report_guide.py
+++ b/proseco/report_guide.py
@@ -68,8 +68,9 @@ def make_report(obsid, rootdir='.'):
     context['include_ids'] = ", ".join([str(val) for val in guides.include_ids])
     context['exclude_ids'] = ", ".join([str(val) for val in guides.exclude_ids])
 
-    # Get information that is not stored in the acqs pickle for space reasons
-    guides.stars = StarsTable.from_agasc(guides.att, date=guides.date)
+    # Get stars if not already set (e.g. if guides is coming from a pickle).  If
+    # guides.stars is already correctly defined this does nothing.
+    guides.set_stars()
 
     # For include/exclude stars, add some bookkeeping (the forced column)
     cand_guides['forced'] = False


### PR DESCRIPTION
In this code the `stars` attribute was always being set even if already set, but without calling the `near_fov_filter` filtering. So there got to be a mismatch between `stars` and `bad_stars_mask`.

A small mystery to me is why this wasn't failing more.  It might have been that it worked as long as none of the stars in the small acq box plot were bad.