### PR TITLE
 Remove use of test(get_version=True)

### DIFF
--- a/proseco/__init__.py
+++ b/proseco/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.4"
+__version__ = "4.4.1"
 
 
 def get_aca_catalog(*args, **kwargs):

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -10,9 +10,7 @@ from .acq import get_acq_catalog, AcqTable
 from .fid import get_fid_catalog, FidTable
 from . import characteristics_acq as ACQ
 from . import characteristics as ACA
-from . import test as test_from_init
-
-VERSION = test_from_init(get_version=True)
+from . import __version__ as VERSION
 
 
 def get_aca_catalog(obsid=0, **kwargs):


### PR DESCRIPTION
Merging to 4.4.x branch when approved, so this should be cherry-picked into master as well.

Passes unit tests.  Functional test (since there is no explicit unit test for version):
```
In [1]: from proseco import get_aca_catalog
In [2]: aca = get_aca_catalog(20603)
In [3]: aca.version
Out[3]: '4.4.1'
```

Fixes #295 
