### PR TITLE
Allow optimizing acq halfw for included star

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,12 @@ exclude_ids_guide   int or list of AGASC IDs of stars to exclude from guide cata
 stars               table of AGASC stars (will be fetched from agasc if None)
 =================== ===============================================================
 
+Within the ``include_halfws_acq`` list, one can supply the value ``0`` for a
+star instead of a typical legal value such as ``60`` or ``120``.  In that case
+proseco will run the normal optimization and choose the best halfwidth for that
+included star.  If the ``include_halfws_acq`` argument is not supplied or set
+to ``[]`` then all halfwidths will be chosen by proseco.
+
 **Debug**
 
 ============== =========================================================

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -139,7 +139,7 @@ class AcqTable(ACACatalogTable):
     # IDs that are included but with halfw=0 which implies to optimize halfw
     # instead of freezing at the provided value.  This attribute is set internally
     # based on the values of include_halfws.
-    include_opt_ids = MetaAttribute(is_kwarg=False)
+    include_optimize_halfw_ids = MetaAttribute(is_kwarg=False, default=())
 
     p_man_errs = MetaAttribute(is_kwarg=False)
     cand_acqs = MetaAttribute(is_kwarg=False)
@@ -464,9 +464,9 @@ class AcqTable(ACACatalogTable):
         # Ensure values are valid box_sizes
         grid_func = interp1d(ACQ.box_sizes, ACQ.box_sizes,
                              kind='nearest', fill_value='extrapolate')
-        self.include_opt_ids = [acq_id for acq_id, halfw,
-                                in zip(self.include_ids, self.include_halfws)
-                                if halfw == 0]
+        self.include_optimize_halfw_ids = [
+            acq_id for acq_id, halfw in zip(self.include_ids, self.include_halfws)
+            if halfw == 0]
 
         self.include_halfws = grid_func(self.include_halfws).tolist()
 
@@ -760,9 +760,9 @@ class AcqTable(ACACatalogTable):
 
         for idx in idxs:
             # Don't optimize halfw for a star that is specified for inclusion
-            # with a valid (non-zero) halfw set.  The set of include_opt_ids is
+            # with a valid (non-zero) halfw set.  The set of include_optimize_halfw_ids is
             # any ids where halfw=0 was provided.
-            if self['id'][idx] in set(self.include_ids) - set(self.include_opt_ids):
+            if self['id'][idx] in set(self.include_ids) - set(self.include_optimize_halfw_ids):
                 continue
 
             p_safe, improved = self.optimize_acq_halfw(idx, p_safe, verbose)

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -42,7 +42,8 @@ def get_acq_catalog(obsid=0, **kwargs):
     :param focus_offset: SIM focus offset [steps] (default=0)
     :param stars: table of AGASC stars (will be fetched from agasc if None)
     :param include_ids: list of AGASC IDs of stars to include in selected catalog
-    :param include_halfws: list of acq halfwidths corresponding to ``include_ids``
+    :param include_halfws: list of acq halfwidths corresponding to ``include_ids``.
+                           For values of ``0`` proseco chooses the best halfwidth(s).
     :param exclude_ids: list of AGASC IDs of stars to exclude from selected catalog
     :param optimize: optimize star catalog after initial selection (default=True)
     :param verbose: provide extra logging info (mostly calc_p_safe) (default=False)
@@ -458,6 +459,10 @@ class AcqTable(ACACatalogTable):
         :param stars: stars table
 
         """
+        # Allow for not providing halfws, in which case proseco chooses.
+        if self.include_halfws is None or len(self.include_halfws) == 0:
+            self.include_halfws = [0] * len(self.include_ids)
+
         if len(self.include_ids) != len(self.include_halfws):
             raise ValueError('include_ids and include_halfws must have same length')
 

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -50,7 +50,8 @@ def get_aca_catalog(obsid=0, **kwargs):
     :param focus_offset: SIM focus offset [steps] (default=0)
     :param stars: table of AGASC stars (will be fetched from agasc if None)
     :param include_ids_acq: list of AGASC IDs of stars to include in acq catalog
-    :param include_halfws_acq: list of acq halfwidths corresponding to ``include_ids``
+    :param include_halfws_acq: list of acq halfwidths corresponding to ``include_ids``.
+                               For values of ``0`` proseco chooses the best halfwidth(s).
     :param exclude_ids_acq: list of AGASC IDs of stars to exclude from acq catalog
     :param include_ids_guide: list of AGASC IDs of stars to include in guide catalog
     :param exclude_ids_guide: list of AGASC IDs of stars to exclude from guide catalog

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -1100,3 +1100,29 @@ def test_acq_include_optimize_halfw_ids():
     assert star['halfw'] == 140  # Specified box size (not optimized)
 
     assert aca.acqs.include_optimize_halfw_ids == [200, 201]
+
+
+@pytest.mark.parametrize('halfw_kwargs', ({}, {'include_halfws_acq': []}))
+def test_acq_include_ids_no_halfws(halfw_kwargs):
+    """
+    Test that force-include acq stars with no halfw provides works.
+    """
+    dark = DARK40.copy()
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(mag=7.0, n_stars=8, size=2000)
+    stars.add_fake_star(yang=200, zang=200, mag=7.5, id=200)
+    stars.add_fake_star(yang=-200, zang=200, mag=10.5, id=201)
+
+    kwargs = mod_std_info(stars=stars, dark=dark,
+                          n_guide=8, n_fid=0, n_acq=8, man_angle=90,
+                          include_ids_acq=[200, 201],
+                          **halfw_kwargs)
+    aca = get_aca_catalog(**kwargs)
+
+    # Confirm that halfw values are good
+    star = aca.get_id(200)
+    assert star['halfw'] == 160  # Large box for a bright star
+    star = aca.get_id(201)
+    assert star['halfw'] == 80  # Small box for faint star
+
+    assert aca.acqs.include_optimize_halfw_ids == [200, 201]

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -1072,3 +1072,31 @@ def test_bad_star_list():
 
     idx = acqs.stars.get_id_idx(bad_id)
     assert acqs.bad_stars_mask[idx]
+
+
+def test_acq_include_optimize_halfw_ids():
+    """
+    Test that force-include acq stars with halfw=0 get halfw optimized.
+    """
+    dark = DARK40.copy()
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(mag=7.0, n_stars=8, size=2000)
+    stars.add_fake_star(yang=200, zang=200, mag=7.5, id=200)
+    stars.add_fake_star(yang=-200, zang=200, mag=10.5, id=201)
+    stars.add_fake_star(yang=-200, zang=-200, mag=10.5, id=202)
+
+    kwargs = mod_std_info(stars=stars, dark=dark,
+                          n_guide=8, n_fid=0, n_acq=8, man_angle=90,
+                          include_ids_acq=[200, 201, 202],
+                          include_halfws_acq=[0, 0, 140])
+    aca = get_aca_catalog(**kwargs)
+
+    # Confirm that halfw values are good
+    star = aca.get_id(200)
+    assert star['halfw'] == 160  # Large box for a bright star
+    star = aca.get_id(201)
+    assert star['halfw'] == 80  # Small box for faint star
+    star = aca.get_id(202)
+    assert star['halfw'] == 140  # Specified box size (not optimized)
+
+    assert aca.acqs.include_optimize_halfw_ids == [200, 201]

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -117,7 +117,8 @@ def test_exception_handling():
                           t_ccd_acq=-10, t_ccd_guide=-10,
                           detector='ACIS-S', sim_offset=0, focus_offset=0,
                           n_guide=8, n_fid=3, n_acq=8,
-                          include_ids_acq=[1], raise_exc=False)  # Fail
+                          include_ids_acq=[1], include_halfws_acq=[100, 120],
+                          raise_exc=False)  # Fail
     assert 'include_ids and include_halfws must have same length' in aca.exception
 
     for obj in (aca, aca.acqs, aca.guides, aca.fids):


### PR DESCRIPTION
This allows proseco to optimize the box size (halfw) for a star that is force included.  This is done by setting include_halfw=0.
```
In [13]: aca = get_aca_catalog(20603, include_ids_acq=[116923672, 40112304, 40113544], include_halfws_acq=[0, 0, 0])

In [14]: aca
Out[14]: 
<ACATable length=11>
 slot  idx      id    type  sz   p_acq    mag    maxmag   yang     zang    dim   res  halfw
int64 int64   int64   str3 str3 float64 float64 float64 float64  float64  int64 int64 int64
----- ----- --------- ---- ---- ------- ------- ------- -------- -------- ----- ----- -----
    0     1         2  FID  8x8   0.000    7.00    8.00  -773.20 -1742.03     1     1    25
    1     2         4  FID  8x8   0.000    7.00    8.00  2140.23   166.63     1     1    25
    2     3         5  FID  8x8   0.000    7.00    8.00 -1826.28   160.17     1     1    25
    3     4  40112304  BOT  6x6   0.689    9.79   11.29 -1644.35  2032.47    20     1   160
    4     5  40113544  BOT  6x6   0.981    7.91    9.41   102.74  1133.37    20     1   160
    5     6  40114416  BOT  6x6   0.919    9.75   11.25   394.22  1204.43    20     1   140
    6     7 116791824  BOT  6x6   0.968    9.15   10.65   622.00  -953.60    20     1   160
    7     8 116923496  ACQ  6x6   0.963    9.14   10.64 -1337.79  1049.27    20     1   120
    0     9 116923528  ACQ  6x6   0.586    9.84   11.34 -2418.65  1088.40    20     1   160
    1    10 116791744  ACQ  6x6   0.606   10.31   11.81   985.38 -1210.19    20     1    60
    2    11 116923672  ACQ  6x6   0.126   10.97   12.47 -2307.80  1442.43    20     1    60
```
