### PR TITLE
Implement capping of catalog MAXMAG to 11.2 mag

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -614,7 +614,7 @@ class AcqTable(ACACatalogTable):
         # Imposters
         ext_box_size = box_size + dither
         kwargs = dict(star_row=acq['row'], star_col=acq['col'],
-                      maxmag=acq['mag'] + acq['mag_err'],  # + 1.5, TO DO: put to characteristics
+                      maxmag=acq['mag'] + acq['mag_err'],
                       box_size=ext_box_size,
                       dark=dark,
                       bgd=bgd,  # TO DO deal with this

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -425,7 +425,7 @@ def merge_cats(fids=None, guides=None, acqs=None):
     if len(guides) > 0:
         guides['slot'] = 0  # Filled in later
         guides['type'] = 'GUI'
-        guides['maxmag'] = guides['mag'] + 1.5
+        guides['maxmag'] = (guides['mag'] + 1.5).clip(None, ACA.max_maxmag)
         guides['p_acq'] = 0
         guides['dim'] = 1
         guides['res'] = 1
@@ -434,7 +434,7 @@ def merge_cats(fids=None, guides=None, acqs=None):
 
     if len(acqs) > 0:
         acqs['type'] = 'ACQ'
-        acqs['maxmag'] = acqs['mag'] + 1.5
+        acqs['maxmag'] = (acqs['mag'] + 1.5).clip(None, ACA.max_maxmag)
         acqs['dim'] = 20
         acqs['sz'] = guide_size
         acqs['res'] = 1

--- a/proseco/characteristics.py
+++ b/proseco/characteristics.py
@@ -17,6 +17,10 @@ CCD = {'row_min': -512.0,
 PIX_2_ARC = 4.96289
 ARC_2_PIX = 1.0 / PIX_2_ARC
 
+# Maximum value of star catalog MAXMAG parameter.  Clip value and implications
+# of clipping discussed in emails circa June 7, 2019 with search key "maxmag".
+max_maxmag = 11.2
+
 # Convenience characteristics
 max_ccd_row = CCD['row_max'] - CCD['row_pad']  # Max allowed row for stars (SOURCE?)
 max_ccd_col = CCD['col_max'] - CCD['col_pad']  # Max allow col for stars (SOURCE?)


### PR DESCRIPTION
Based on discussions in emails ("maxmag" near June 7, 2019), the MAXMAG parameter in commanded star catalogs should be capped at 11.2 mag.  This makes that change in proseco catalogs.

This PR does **not** implement capping of the `maxmag` parameter found in the acq star selection code.  That value of `maxmag` is actually a different quantity, defined as 1-sigma above the star mag.  In practice that will rarely be above 11.2 for selected stars, but in any case I would rather leave the acq selection algorithm unchanged so this PR does not introduce any change in star selection.

cc: @mbaski @jskrist 