### PR TITLE
Pickle dark_date always and use it if existing for selecting dark map

### DIFF
--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -180,7 +180,6 @@ class ACATable(ACACatalogTable):
     optimize = MetaAttribute(default=True)
     call_args = MetaAttribute(default={})
     version = MetaAttribute()
-    dark_date = MetaAttribute()
 
     # For validation with get_aca_catalog(obsid), store the starcheck
     # catalog in the ACATable meta.

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -568,31 +568,33 @@ class ACACatalogTable(BaseCatalogTable):
         if self.dark_date:
             dark_date = self.dark_date
             select = 'nearest'
+            dark_id = get_dark_cal_id(date=dark_date, select=select)
+
+            # Warn if the pickled dark_date is not the same as we would have gotten based
+            # on the observation date.
+            dark_id_for_date = get_dark_cal_id(date=self.date, select='before')
+            if dark_id != dark_id_for_date:
+                warnings.warn(f'Unexpected dark_date: '
+                              f'dark_id nearest dark_date={dark_date} is {dark_id} '
+                              f'but dark_id before obs date={self.date} is {dark_id_for_date}')
         else:
             dark_date = self.date
             select = 'before'
+            dark_id = get_dark_cal_id(date=dark_date, select=select)
 
         # Dark current map handling.  If asking for `dark` attribute without having set
         # it then auto-fetch from mica.  Note that get_dark_cal_image caches returned values
         # using LRU cache on all params, so this is efficient for the different
         # catalog tables.
-        self.log(f'Getting dark cal image at date={dark_date} t_ccd={self.t_ccd:.1f} '
+        self.log(f'Getting dark cal image {dark_id} at date={dark_date} t_ccd={self.t_ccd:.1f} '
                  f'select={select}')
         self.dark = get_dark_cal_image(date=dark_date, select=select,
                                        t_ccd_ref=self.t_ccd,
                                        aca_image=False)
 
         # In all cases set self.dark_date to be the actual date of the dark cal
-        # we are using, not what might have been set on input. But issue a warning
-        # if there is a mismatch.
-        dark_id = get_dark_cal_id(date=dark_date, select=select)
-        new_dark_date = dark_id[:4] + ':' + dark_id[4:]
-
-        if self.dark_date and self.dark_date != new_dark_date:
-            warnings.warn(f'Mismatch between pickled dark_date {self.dark_date} and nearest '
-                          f'available dark cal in the archive at {new_dark_date}')
-
-        self.dark_date = new_dark_date
+        # we are using, not what might have been set on input.
+        self.dark_date = dark_id[:4] + ':' + dark_id[4:]
 
         return self._dark
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -4,6 +4,7 @@ import functools
 import pickle
 import inspect
 import time
+import warnings
 from copy import copy
 from pathlib import Path
 
@@ -582,9 +583,16 @@ class ACACatalogTable(BaseCatalogTable):
                                        aca_image=False)
 
         # In all cases set self.dark_date to be the actual date of the dark cal
-        # we are using, not what might have been set on input.
+        # we are using, not what might have been set on input. But issue a warning
+        # if there is a mismatch.
         dark_id = get_dark_cal_id(date=dark_date, select=select)
-        self.dark_date = dark_id[:4] + ':' + dark_id[4:]
+        new_dark_date = dark_id[:4] + ':' + dark_id[4:]
+
+        if self.dark_date and self.dark_date != new_dark_date:
+            warnings.warn(f'Mismatch between pickled dark_date {self.dark_date} and nearest '
+                          f'available dark cal in the archive at {new_dark_date}')
+
+        self.dark_date = new_dark_date
 
         return self._dark
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -540,6 +540,7 @@ class ACACatalogTable(BaseCatalogTable):
     t_ccd_acq = MetaAttribute()
     t_ccd_guide = MetaAttribute()
     date = MetaAttribute()
+    dark_date = MetaAttribute()
     dither_acq = MetaAttribute()
     dither_guide = MetaAttribute()
     detector = MetaAttribute()
@@ -561,15 +562,28 @@ class ACACatalogTable(BaseCatalogTable):
         if hasattr(self, '_dark'):
             return self._dark
 
+        # If self.dark_date is already set (most likely after unpickling an existing
+        # catalog), then use that instead of the observation date for getting the dark map.
+        if self.dark_date:
+            dark_date = self.dark_date
+            select = 'nearest'
+        else:
+            dark_date = self.date
+            select = 'before'
+
         # Dark current map handling.  If asking for `dark` attribute without having set
         # it then auto-fetch from mica.  Note that get_dark_cal_image caches returned values
         # using LRU cache on all params, so this is efficient for the different
         # catalog tables.
-        self.log(f'Getting dark cal image at date={self.date} t_ccd={self.t_ccd:.1f}')
-        self.dark = get_dark_cal_image(date=self.date, select='before',
+        self.log(f'Getting dark cal image at date={dark_date} t_ccd={self.t_ccd:.1f} '
+                 f'select={select}')
+        self.dark = get_dark_cal_image(date=dark_date, select=select,
                                        t_ccd_ref=self.t_ccd,
                                        aca_image=False)
-        dark_id = get_dark_cal_id(date=self.date, select='before')
+
+        # In all cases set self.dark_date to be the actual date of the dark cal
+        # we are using, not what might have been set on input.
+        dark_id = get_dark_cal_id(date=dark_date, select=select)
         self.dark_date = dark_id[:4] + ':' + dark_id[4:]
 
         return self._dark

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -760,3 +760,17 @@ def test_includes_for_obsid():
 
     out = includes_for_obsid(8008)
     assert out == exp
+
+
+def test_dark_date_warning():
+    aca = get_aca_catalog(**STD_INFO)
+    acap = pickle.loads(pickle.dumps(aca))
+    assert acap.dark_date == '2017:272'
+
+    # Fudge date forward, after the 2018:002 dark cal
+    acap.date = '2018:010'
+    with pytest.warns(None) as warns:
+        acap.dark  # Accessing the `dark` property triggers code to read it (and warn)
+
+    assert len(warns) == 1
+    assert 'Unexpected dark_date: dark_id nearest dark_date' in str(warns[0].message)


### PR DESCRIPTION
Trying to avoid this:
```
In [5]: acas = pickle.load(gzip.open('C://Users//unksm//Downloads/11478_proseco
   ...: .pkl.gz', 'rb'))

In [6]: acas[47759].dark_date
Out[6]: '2019:203'

In [7]: acas[47759].dark
Out[7]:
array([[ 118.17330933,   70.96971893,   20.10654068, ...,  258.32196045,
         411.29510498,  344.21810913],
       [   0.        ,   20.52358055,  167.46463013, ...,   19.52788734,
          22.76825142,    0.        ],
       [   0.        ,   12.25281143,   18.72343826, ...,   67.4727478 ,
          32.30231476,    0.        ],
       ...,
       [ 123.90538788,   70.99282074,  128.89112854, ...,   15.33648682,
           7.7166934 ,    0.        ],
       [ 173.1265564 ,   36.64894485,   16.11512184, ...,  133.4210968 ,
          10.49938488,    0.        ],
       [   0.        ,   39.4043541 ,  114.90283203, ...,   62.78889847,
          14.20818233,  115.17153168]], dtype=float32)

In [8]: acas[47759].dark_date
Out[8]: '2019:288' 
```
