### PR TITLE
Apply temperature scaling to guide faint mag limit

### DIFF
--- a/proseco/characteristics_guide.py
+++ b/proseco/characteristics_guide.py
@@ -12,6 +12,17 @@ min_guide_count = 4.0
 # Add this padding to region checked for bad pixels (in addition to dither)
 dither_pix_pad = 0.4
 
+# Reference faint magnitude limit and CCD temperature for guide star candidate
+# selection.  The faint mag limit is scaled via the actual CCD temperature in
+# the selection process (maintaining equivalent SNR relative to dark current).
+#
+# The reference temperature is set to -7.8 to reflect that circa Jan 2020 we had
+# not be applying any scaling and nominally allowing stars as faint as 10.3 mag
+# at temperatures up to -7.8 C.  In practice other constraints may kick in, but
+# for the initial box criteria for candidate selection this is used.
+ref_faint_mag_t_ccd = -7.8
+ref_faint_mag = 10.3
+
 # Error / check labeling
 errs = {'mag range': 1,
         'aspq1': 2,


### PR DESCRIPTION
This applies temperature scaling to the 10.3 mag faint limit applied when selecting candidate guide stars.

The reference temperature is set to -7.8 to reflect that circa Jan 2020 we had not be applying any scaling and nominally allowing stars as faint as 10.3 mag at temperatures up to -7.8 C.  In practice other constraints may kick in, but for the initial box criteria for candidate selection this seems reasonable.

Going forward, as the ACA planning limit is increased this may well start excluding stars and correctly reflect our operational experience that too-faint guide stars in the catalog can increase the risk of safing.

We need a discussion about deployment strategy.  In theory this could be merged since the planning limit is -7.8 C so there should be no difference between this version and flight.


Closes #235 
Closes https://github.com/sot/ska-projects/issues/127