### PR TITLE
Fixes for shiny Ska3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.pkl
 *.npz
 /validate
+/obs?????
+/.idea
+/.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -628,7 +628,8 @@ class AcqTable(ACACatalogTable):
         acqs_init = cand_acqs[acq_indices]
 
         # Transfer to acqs (which at this point is an empty table)
-        self.add_columns(acqs_init.columns.values())
+        for col in acqs_init.itercols():
+            self[col.info.name] = col
 
     def calc_p_brightest(self, acq, box_size, man_err=0, bgd=0):
         """

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -1,6 +1,7 @@
 import traceback
 import numpy as np
 from itertools import count
+import copy
 
 from astropy.table import Column, Table
 
@@ -190,6 +191,12 @@ class ACATable(ACACatalogTable):
     # method below).
     t_ccd_eff_acq = MetaAttribute(is_kwarg=False)
     t_ccd_eff_guide = MetaAttribute(is_kwarg=False)
+
+    def __copy__(self):
+        # Astropy Table now does a light key-only copy of the `meta` dict, so
+        # copy.copy(aca) does not copy the underlying table attributes.  Force
+        # a deepcopy instead.
+        return copy.deepcopy(self)
 
     @property
     def t_ccd(self):

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -507,7 +507,8 @@ class BaseCatalogTable(Table):
         kwargs.setdefault('bad_stars', np.zeros(len(kwargs['stars']), dtype=bool))
 
         fig = plot_stars(attitude=self.att, ax=ax, **kwargs)
-        plt.show()
+        if 'agg' not in plt.get_backend().lower():
+            plt.show()
 
         return fig
 

--- a/proseco/tests/timing.py
+++ b/proseco/tests/timing.py
@@ -1,0 +1,39 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Provide a function to check for timing regressions for any changes.
+"""
+
+import time
+import sys
+
+import numpy as np
+
+from proseco import get_aca_catalog
+from proseco.tests.test_common import mod_std_info
+
+
+def time_get_aca_catalog(n_samples=100):
+    """
+    Get n_samples catalogs for standard parameters (all at the same 2018:001) date.
+    """
+
+    np.random.seed(0)
+
+    ras = np.random.uniform(0, 360, size=n_samples)
+    decs = np.random.uniform(-90, 90, size=n_samples)
+    rolls = np.random.uniform(0, 360, size=n_samples)
+
+    # Get rid of initial imports or one-time startup stuff (e.g. in AGASC)
+    get_aca_catalog(**mod_std_info())
+
+    t0 = time.time()
+    for ra, dec, roll in zip(ras, decs, rolls):
+        print('.', end='')
+        sys.stdout.flush()
+        get_aca_catalog(**mod_std_info(att=(ra, dec, roll)))
+
+    t1 = time.time()
+    print()
+
+    print(f'Got {n_samples} catalogs in {(t1 - t0) / n_samples:.3f} secs (mean)')


### PR DESCRIPTION
## Description

This has some changes that are required to pass tests in ska3-shiny (Python 3.6 version).  Details are given in the commit messages.

This branch passes tests in current ska3-flight.  The only catch is that 186897d will be slower in ska3-flight.

- [x] Passes unit tests on MacOS (ska3-flight)
- [x] Passes unit tests on MacOS (shiny: astropy 4.0.1, numpy 1.18, etc)
- [x] Timing regression testing acceptable

### Timing

Running `proseco/tests/timing.py : time_get_aca_catalog(n_samples=100)`

- ska3-flight : master (4.8.1 @ 52b75ee):  370 ms / catalog
- ska3-flight : shiny-fix (6dd88ea): 388 msec / catalog (5% slower)
- shiny : shiny-fix (6dd88ea): 317 msec / catalog (14% faster)

So this is a little slower in current Ska3-flight, but will be faster in shiny.