### PR TITLE
Fix optimizing halfw for case of many include_ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.ipynb
 *.pkl
 *.npz
+/validate
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -568,12 +568,49 @@ class AcqTable(ACACatalogTable):
 
         self.log(f'Getting initial catalog from {len(cand_acqs)} candidates')
 
-        # Start the lists of acq indices and box sizes with the values from
-        # the include lists.  Usually these will be empty.
-        acq_indices = [cand_acqs.get_id_idx(id) for id in self.include_ids]
-        box_sizes = self.include_halfws[:]  # make a copy
+        # Build up the initial catalog as a list of indices into cand_acqs
+        # and the corresponding initial box size (halfw).
+        acq_indices = []
+        box_sizes = []
 
-        # Accumulate indices and box sizes of candidate acq stars that meet
+        # Start with force-include stars, if any.
+        if self.include_ids:
+            self.log(f'Processing force-include ids={self.include_ids} '
+                     f'halfws={self.include_halfws}')
+
+            # Re-order candidate acqs to put those in the include list first
+            ok = np.in1d(cand_acqs['id'], self.include_ids)
+            idxs = np.concatenate([np.where(ok)[0], np.where(~ok)[0]])
+            cand_acqs = cand_acqs[idxs]
+
+            n_include = len(self.include_ids)
+            for min_p_acq in (0.75, 0.5, 0.25, 0.05, -1):
+                if len(acq_indices) < n_include:
+                    # Select candidates meeting min_p_acq, and update
+                    # acq_indices, box_sizes in place
+                    self.select_best_p_acqs(cand_acqs[:n_include], min_p_acq,
+                                            acq_indices, box_sizes)
+                else:
+                    # Because of the final min_p_acq = -1, this is guaranteed to finish.
+                    break
+
+            # This should never happen but be careful
+            if len(acq_indices) != n_include:
+                raise RuntimeError(f'failure in force-include')
+
+            # For include stars where the halfw is not going to be optimized
+            # then then override the box size that was just found with the
+            # user-supplied value.
+            for include_id, include_halfw in zip(self.include_ids, self.include_halfws):
+                if include_id not in self.include_optimize_halfw_ids:
+                    # Find the position in box_sizes that corresponds to include_id
+                    # and set to the specified include_halfw.
+                    for idx in range(len(acq_indices)):
+                        if include_id == cand_acqs[idx]['id']:
+                            box_sizes[idx] = include_halfw
+                            break
+
+        # Now accumulate indices and box sizes of candidate acq stars that meet
         # successively less stringent minimum p_acq.
         for min_p_acq in (0.75, 0.5, 0.25, 0.05):
             if len(acq_indices) < self.n_acq:

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -590,9 +590,6 @@ class AcqTable(ACACatalogTable):
                     # acq_indices, box_sizes in place
                     self.select_best_p_acqs(cand_acqs[:n_include], min_p_acq,
                                             acq_indices, box_sizes)
-                else:
-                    # Because of the final min_p_acq = -1, this is guaranteed to finish.
-                    break
 
             # This should never happen but be careful
             if len(acq_indices) != n_include:

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -1084,7 +1084,7 @@ def test_acq_include_optimize_halfw_ids():
     star = aca.get_id(200)
     assert star['halfw'] == 160  # Large box for a bright star
     star = aca.get_id(201)
-    assert star['halfw'] == 80  # Small box for faint star
+    assert star['halfw'] == 60  # Small box for faint star
     star = aca.get_id(202)
     assert star['halfw'] == 140  # Specified box size (not optimized)
 
@@ -1112,6 +1112,24 @@ def test_acq_include_ids_no_halfws(halfw_kwargs):
     star = aca.get_id(200)
     assert star['halfw'] == 160  # Large box for a bright star
     star = aca.get_id(201)
-    assert star['halfw'] == 80  # Small box for faint star
+    assert star['halfw'] == 60  # Small box for faint star
 
     assert aca.acqs.include_optimize_halfw_ids == [200, 201]
+
+
+def test_acq_include_ids_no_halfws_full_catalog():
+    """Test for all 8 acq_ids provided with no include_halfws provided"""
+    stars = StarsTable.empty()
+    dark = DARK40.copy()
+    stars.add_fake_constellation(mag=np.linspace(9.5, 10.6, 8), n_stars=8, size=2000)
+    kwargs = mod_std_info(stars=stars, dark=dark, n_guide=8, n_fid=0, n_acq=8, man_angle=30)
+    aca = get_aca_catalog(**kwargs)
+    exp_halfws = [160, 160, 160, 160, 60, 60, 80, 60]
+    assert np.all(aca.acqs['halfw'] == exp_halfws)
+
+    # Now force-include all acq stars but with halfws re-optimized.
+    kwargs['include_ids_acq'] = aca.acqs['id']
+    aca2 = get_aca_catalog(**kwargs)
+    # Not exactly the same, but close enough.
+    exp_halfws = [160, 160, 160, 160, 120, 60, 80, 60]
+    assert np.all(aca2.acqs['halfw'] == exp_halfws)

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -1072,7 +1072,7 @@ def test_acq_include_optimize_halfw_ids():
     stars.add_fake_constellation(mag=7.0, n_stars=8, size=2000)
     stars.add_fake_star(yang=200, zang=200, mag=7.5, id=200)
     stars.add_fake_star(yang=-200, zang=200, mag=10.5, id=201)
-    stars.add_fake_star(yang=-200, zang=-200, mag=10.5, id=202)
+    stars.add_fake_star(yang=-200, zang=-200, mag=10.99, id=202)
 
     kwargs = mod_std_info(stars=stars, dark=dark,
                           n_guide=8, n_fid=0, n_acq=8, man_angle=90,
@@ -1100,7 +1100,7 @@ def test_acq_include_ids_no_halfws(halfw_kwargs):
     stars = StarsTable.empty()
     stars.add_fake_constellation(mag=7.0, n_stars=8, size=2000)
     stars.add_fake_star(yang=200, zang=200, mag=7.5, id=200)
-    stars.add_fake_star(yang=-200, zang=200, mag=10.5, id=201)
+    stars.add_fake_star(yang=-200, zang=200, mag=10.99, id=201)
 
     kwargs = mod_std_info(stars=stars, dark=dark,
                           n_guide=8, n_fid=0, n_acq=8, man_angle=90,

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -1133,3 +1133,21 @@ def test_acq_include_ids_no_halfws_full_catalog():
     # Not exactly the same, but close enough.
     exp_halfws = [160, 160, 160, 160, 120, 60, 80, 60]
     assert np.all(aca2.acqs['halfw'] == exp_halfws)
+
+
+def test_acq_include_ids_all_halfws_full_catalog():
+    """Test for all 8 acq_ids provided with no include_halfws provided"""
+    stars = StarsTable.empty()
+    dark = DARK40.copy()
+    stars.add_fake_constellation(mag=np.linspace(9.5, 10.6, 8), n_stars=8, size=2000)
+    kwargs = mod_std_info(stars=stars, dark=dark, n_guide=8, n_fid=0, n_acq=8, man_angle=30)
+    aca = get_aca_catalog(**kwargs)
+    exp_halfws = [160, 160, 160, 160, 60, 60, 80, 60]
+    assert np.all(aca.acqs['halfw'] == exp_halfws)
+
+    # Now force-include all acq stars but with halfws re-optimized.
+    kwargs['include_ids_acq'] = aca.acqs['id']
+    kwargs['include_halfws_acq'] = aca.acqs['halfw']
+    aca2 = get_aca_catalog(**kwargs)
+    # Not exactly the same, but close enough.
+    assert np.all(aca2.acqs['halfw'] == aca.acqs['halfw'])


### PR DESCRIPTION
## Description

When `include_ids_acq` included at least 6 or 7 of the stars in the catalog and no halfwidth values are provided, then the halfw optimization broke down and all stars were assigned a halfwidth of 60. This was related to the algorithm always assigning an initial halfw=60 for all of those stars.  The optimizing algorithm can then get stuck in this case (which doesn't every normally occur because the starting halfws are chosen carefully).

This fix allows for the included stars to have the same initial halfw value (before starting optimization) as if they were naturally selected.

## Testing

- [x] Passes unit tests on MacOS
- No additional functional testing, new unit test added

Fixes issue noted by @jskrist https://github.com/sot/proseco/pull/297#issuecomment-584300145.