### PR TITLE
Add a test of calc_p_safe for two identical catalogs

### DIFF
--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -1149,5 +1149,6 @@ def test_acq_include_ids_all_halfws_full_catalog():
     kwargs['include_ids_acq'] = aca.acqs['id']
     kwargs['include_halfws_acq'] = aca.acqs['halfw']
     aca2 = get_aca_catalog(**kwargs)
-    # Not exactly the same, but close enough.
     assert np.all(aca2.acqs['halfw'] == aca.acqs['halfw'])
+
+    assert aca.acqs.calc_p_safe() == aca2.acqs.calc_p_safe()


### PR DESCRIPTION
## Description

For two catalogs that came about in different ways but with the same stars and halfwidths, confirm that the p_safe values are identical.  Because the p_safe calculation is independent of how the catalog is constructed this must succeed, but we check it anyway.

Also fixes an unrelated leftover comment.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)

