### PR TITLE
Keep box_sizes in the same order as the acq_indices

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -598,13 +598,14 @@ class AcqTable(ACACatalogTable):
             # For include stars where the halfw is not going to be optimized
             # then then override the box size that was just found with the
             # user-supplied value.
-            include_halfw_for_id = {iid: halfw for iid, halfw in zip(self.include_ids, self.include_halfws)}
+            include_halfw_for_id = {iid: halfw for iid, halfw in zip(self.include_ids,
+                                                                     self.include_halfws)}
 
             # We want the boxes to reference the same stars that the acq_indices index
             for box_idx, acq_idx in enumerate(acq_indices):
                 if (cand_acqs[acq_idx]['id'] in self.include_ids and
-                    cand_acqs[acq_idx]['id'] not in self.include_optimize_halfw_ids):
-                        box_sizes[box_idx] = include_halfw_for_id[cand_acqs[acq_idx]['id']]
+                        cand_acqs[acq_idx]['id'] not in self.include_optimize_halfw_ids):
+                    box_sizes[box_idx] = include_halfw_for_id[cand_acqs[acq_idx]['id']]
 
         # Now accumulate indices and box sizes of candidate acq stars that meet
         # successively less stringent minimum p_acq.

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -474,6 +474,7 @@ class AcqTable(ACACatalogTable):
             if halfw == 0]
 
         self.include_halfws = grid_func(self.include_halfws).tolist()
+
         super().process_include_ids(cand_acqs, stars)
 
     def select_best_p_acqs(self, cand_acqs, min_p_acq, acq_indices, box_sizes):
@@ -576,6 +577,7 @@ class AcqTable(ACACatalogTable):
         if self.include_ids:
             self.log(f'Processing force-include ids={self.include_ids} '
                      f'halfws={self.include_halfws}')
+
             # Re-order candidate acqs to put those in the include list first
             ok = np.in1d(cand_acqs['id'], self.include_ids)
             idxs = np.concatenate([np.where(ok)[0], np.where(~ok)[0]])
@@ -588,7 +590,6 @@ class AcqTable(ACACatalogTable):
                     # acq_indices, box_sizes in place
                     self.select_best_p_acqs(cand_acqs[:n_include], min_p_acq,
                                             acq_indices, box_sizes)
-
 
             # This should never happen but be careful
             if len(acq_indices) != n_include:

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -1152,3 +1152,30 @@ def test_acq_include_ids_all_halfws_full_catalog():
     assert np.all(aca2.acqs['halfw'] == aca.acqs['halfw'])
 
     assert aca.acqs.calc_p_safe() == aca2.acqs.calc_p_safe()
+
+
+def test_obsid_47250():
+    """Test include all 8 acq ids has right halfws for right stars"""
+
+    # This uses the attitude/stars from obsid 47250 in APR2720
+    att = [0.37484371, -0.40057847, -0.79053942,  0.27216999]
+    stars = StarsTable.from_agasc(att, date='2018:230')
+    dark = DARK40.copy()
+    kwargs = mod_std_info(att=att, stars=stars, dark=dark,
+                          n_guide=8, n_fid=0, n_acq=8, man_angle=90)
+    kwargs['include_halfws_acq'] =  [140, 160, 160, 160, 160, 160, 160, 160]
+    kwargs['include_ids_acq'] =  [810423632,
+                                  810428640,
+                                  812125920,
+                                  812130960,
+                                  812131816,
+                                  886441184,
+                                  810427792,
+                                  810428880]
+    aca = get_aca_catalog(**kwargs)
+
+    # Confirm that the included stars have the assigned halfws
+    for id, halfw in zip(kwargs['include_ids_acq'],
+                         kwargs['include_halfws_acq']):
+        assert aca.acqs.get_id(id)['halfw'] == halfw
+

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -1158,24 +1158,23 @@ def test_obsid_47250():
     """Test include all 8 acq ids has right halfws for right stars"""
 
     # This uses the attitude/stars from obsid 47250 in APR2720
-    att = [0.37484371, -0.40057847, -0.79053942,  0.27216999]
+    att = [0.37484371, -0.40057847, -0.79053942, 0.27216999]
     stars = StarsTable.from_agasc(att, date='2018:230')
     dark = DARK40.copy()
     kwargs = mod_std_info(att=att, stars=stars, dark=dark,
                           n_guide=8, n_fid=0, n_acq=8, man_angle=90)
-    kwargs['include_halfws_acq'] =  [140, 160, 160, 160, 160, 160, 160, 160]
-    kwargs['include_ids_acq'] =  [810423632,
-                                  810428640,
-                                  812125920,
-                                  812130960,
-                                  812131816,
-                                  886441184,
-                                  810427792,
-                                  810428880]
+    kwargs['include_halfws_acq'] = [140, 160, 160, 160, 160, 160, 160, 160]
+    kwargs['include_ids_acq'] = [810423632,
+                                 810428640,
+                                 812125920,
+                                 812130960,
+                                 812131816,
+                                 886441184,
+                                 810427792,
+                                 810428880]
     aca = get_aca_catalog(**kwargs)
 
     # Confirm that the included stars have the assigned halfws
     for id, halfw in zip(kwargs['include_ids_acq'],
                          kwargs['include_halfws_acq']):
         assert aca.acqs.get_id(id)['halfw'] == halfw
-


### PR DESCRIPTION
## Description

Keep box_sizes in the same order as the acq_indices


## Testing

- [x] Passes unit tests on linux (of MacOS, linux, Windows (at least one required))
- [x] Functional testing (added new test of the bug as seen in the wild, apparently [Add a test for Jean](https://github.com/sot/proseco/commit/2d15cda96b50961d14bb06f41ba5d0953d20cadb) didn't get us all the way there)

Fixes #323 