### PR TITLE
Fix bug in halfws for force-include acq stars

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -603,7 +603,7 @@ class AcqTable(ACACatalogTable):
                     # Find the position in box_sizes that corresponds to include_id
                     # and set to the specified include_halfw.
                     for idx in range(len(acq_indices)):
-                        if include_id == cand_acqs[idx]['id']:
+                        if include_id == cand_acqs[acq_indices[idx]]['id']:
                             box_sizes[idx] = include_halfw
                             break
 


### PR DESCRIPTION
## Description

This fixes #323 and supercedes #324. The actual bug fix is simple but I spent some time understanding how it can come about and why the original tests did not show a problem.  In short the problem comes up when the initial `p_acq` for included candidate stars does not increase monotonically with decreasing `mag`.  This can happen because of a spoiler or hot pixel.

This only impacts cases with more than one included star.  In actual star selection with MATLAB choosing more than one star is not common and typical practice now would be to not explicitly select the halfwidths.  It has a definite impact in starcheck which uses force-include of all stars and halfwidths for every catalog.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing

Also ran this test from #324 and confirmed that the update changes this test from fail to pass, but did not include in the final PR.
```
def test_obsid_47250():
    """Test include all 8 acq ids has right halfws for right stars"""

    # This uses the attitude/stars from obsid 47250 in APR2720
    att = [0.37484371, -0.40057847, -0.79053942, 0.27216999]
    stars = StarsTable.from_agasc(att, date='2018:230')
    dark = DARK40.copy()
    kwargs = mod_std_info(att=att, stars=stars, dark=dark,
                          n_guide=8, n_fid=0, n_acq=8, man_angle=90)
    kwargs['include_halfws_acq'] = [140, 160, 160, 160, 160, 160, 160, 160]
    kwargs['include_ids_acq'] = [810423632,
                                 810428640,
                                 812125920,
                                 812130960,
                                 812131816,
                                 886441184,
                                 810427792,
                                 810428880]
    aca = get_aca_catalog(**kwargs)

    # Confirm that the included stars have the assigned halfws
    for id, halfw in zip(kwargs['include_ids_acq'],
                         kwargs['include_halfws_acq']):
        assert aca.acqs.get_id(id)['halfw'] == halfw
```

Fixes #323
Closes #324