### PR TITLE
Update flake8 checking for recent version of flake8

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -16,6 +16,4 @@ jobs:
     - name: Lint with flake8
       run: |
         pip install flake8
-        # Note: only check files in Ska.engarchive package.  Many other files in
-        # the repo are not maintained as PEP8 compliant.
-        flake8 . --count --exclude=docs/conf.py --ignore=W504 --max-line-length=100 --show-source --statistics
+        flake8 . --count --exclude=docs/conf.py --ignore=W504,E402,F541 --max-line-length=100 --show-source --statistics


### PR DESCRIPTION
## Description

It looks like more recent versions of flake8, pyflakes, pycodestyle apply more stringent testing.

There is a new test on f-strings (F541), and for some reason the import order test (E402) no longer seems to respect the `# noqa` on a code line within the imports (as required to set the matplotlib backend before import `pyplot`). I fiddled with this a bit before giving up and just expanding the list of checks to exclude.

## Testing

N/A, no code changes.
