### PR TITLE
Add include/exclude of fids by index/id

### DIFF
--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -57,6 +57,9 @@ def get_aca_catalog(obsid=0, **kwargs):
     :param include_halfws_acq: list of acq halfwidths corresponding to ``include_ids``.
                                For values of ``0`` proseco chooses the best halfwidth(s).
     :param exclude_ids_acq: list of AGASC IDs of stars to exclude from acq catalog
+    :param include_ids_fid: list of fiducial lights to include by index.  If no possible
+                            sets of fids include the id, no fids will be selected.
+    :param exclude_ids_fid: list of fiducial lights to exclude by index
     :param include_ids_guide: list of AGASC IDs of stars to include in guide catalog
     :param exclude_ids_guide: list of AGASC IDs of stars to exclude from guide catalog
     :param optimize: optimize star catalog after initial selection (default=True)
@@ -303,8 +306,10 @@ class ACATable(ACACatalogTable):
         # IF get_fid_catalog returned a good catalog,
         #    OR no fids were requested,
         #    OR no candidate fids are available,
+        #    OR no candidate fid sets are available
         # THEN no optimization action required here.
-        if len(self.fids) > 0 or self.n_fid == 0 or len(self.fids.cand_fids) == 0:
+        if (len(self.fids) > 0 or self.n_fid == 0 or len(self.fids.cand_fids) == 0 or
+                len(self.fids.cand_fid_sets) == 0):
             return
 
         # Start with the no-fids optimum catalog and save required info to restore

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -556,6 +556,8 @@ class ACACatalogTable(BaseCatalogTable):
     exclude_ids_acq = IntListMetaAttribute(default=[])
     include_ids_guide = IntListMetaAttribute(default=[])
     exclude_ids_guide = IntListMetaAttribute(default=[])
+    include_ids_fid = IntListMetaAttribute(default=[])
+    exclude_ids_fid = IntListMetaAttribute(default=[])
     optimize = MetaAttribute(default=True)
     verbose = MetaAttribute(default=False)
     print_log = MetaAttribute(default=False)
@@ -1467,6 +1469,8 @@ def get_kwargs_from_starcheck_text(obs_text, include_cat=False, force_catalog=Fa
             kw['include_halfws_acq'] = cat['halfw'][ok].tolist()
             ok = np.in1d(cat['type'], ('GUI', 'BOT'))
             kw['include_ids_guide'] = cat['id'][ok].tolist()
+            ok = np.in1d(cat['type'], ('FID'))
+            kw['include_ids_fid'] = cat['id'][ok].tolist()
 
     try:
         targ = get_targ(obs_text)
@@ -1506,5 +1510,8 @@ def includes_for_obsid(obsid):
 
     ok = np.in1d(cat['type'], ('GUI', 'BOT'))
     out['include_ids_guide'] = cat['id'][ok].tolist()
+
+    ok = np.in1d(cat['type'], ('FID'))
+    out['include_ids_fid'] = cat['id'][ok].tolist()
 
     return out

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -178,15 +178,11 @@ class FidTable(ACACatalogTable):
             cand_fid_sets = [fid_set for fid_set in FID.fid_sets[self.detector]
                              if fid_set <= cand_fids_ids]
 
-        if len(self.include_ids_fid) > 0:
-            ok = np.ones(len(cand_fid_sets), dtype=bool)
-            for fidid in self.include_ids_fid:
-                ok = ok & np.array([fidid in fid_set for fid_set in cand_fid_sets])
-            if not np.all(ok):
-                self.log(f'Reducing fid sets from {len(cand_fid_sets)} to '
-                         f'{np.count_nonzero(ok)} via include_ids_fid')
-            cand_fid_sets = [fid_set for idx, fid_set in enumerate(cand_fid_sets)
-                             if ok[idx]]
+        # Restrict candidate fid sets to those that entirely contain the include_ids_set
+        include_ids_set = set(self.include_ids_fid)
+        cand_fid_sets = [fid_set for fid_set in cand_fid_sets if fid_set >= include_ids_set]
+        self.log(f'Reducing fid sets to those that include fid ids {self.include_ids_fid}')
+
         return cand_fid_sets
 
     def set_slot_column(self):

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -312,17 +312,25 @@ class FidTable(ACACatalogTable):
 
         self.log(f'Initial candidate fid ids are {cand_fids["id"].tolist()}')
 
-        # Reject candidates that are off CCD, have a bad pixel, or are spoiled
+        # First check that any manually included fid ids are valid by seeing if
+        # the supplied fid is in the initial ids for this detector.
+        if id_diff := set(self.include_ids_fid) - set(cand_fids['id']):
+            raise ValueError(f'included fid ids {id_diff} are not valid')
+
+        # Then reject candidates that are off CCD, have a bad pixel, are spoiled,
+        # or are manually excluded, unless the candidates are forced/manually included.
         # Check for spoilers only against stars that are bright enough and on CCD
         # (within dither).
         idx_bads = []
         stars_mask = ((self.stars['mag'] < FID.fid_mag - ACA.col_spoiler_mag_diff) &
                       (np.abs(self.stars['row']) < 512 + self.dither_guide.row))
         for idx, fid in enumerate(cand_fids):
-            if (self.off_ccd(fid) or
-                    self.near_hot_or_bad_pixel(fid) or
-                    self.has_column_spoiler(fid, self.stars, stars_mask) or
-                    self.is_excluded(fid)):
+            excluded = (self.off_ccd(fid)
+                        or self.near_hot_or_bad_pixel(fid)
+                        or self.has_column_spoiler(fid, self.stars, stars_mask)
+                        or self.is_excluded(fid))
+            included = fid['id'] in self.include_ids_fid
+            if not included and excluded:
                 idx_bads.append(idx)
 
         if idx_bads:

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -747,7 +747,8 @@ def test_includes_for_obsid():
                                31075368,
                                31982136,
                                32375384],
-           'include_ids_guide': [31075128, 31076560, 31463496, 31983336, 32374896]}
+           'include_ids_guide': [31075128, 31076560, 31463496, 31983336, 32374896],
+           'include_ids_fid': [1, 5, 6]}
 
     out = includes_for_obsid(8008)
     assert out == exp

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -714,7 +714,7 @@ def test_force_catalog_from_starcheck():
     Dynamic Mag Limits: Yellow 9.99          Red 10.17"""
 
     aca = get_aca_catalog(obs + '--force-catalog')
-    assert aca['id'].tolist() == [1, 5, 6,  # NOTE: fids are not forced (yet)
+    assert aca['id'].tolist() == [1, 4, 5,
                                   764677800,
                                   765069008,
                                   765069552,

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -216,13 +216,7 @@ def test_fid_hot_pixel_reject():
 
 def test_fids_include_exclude():
     """
-    Test include and exclude stars for guide.  This uses a catalog with 11 stars:
-    - 8 bright stars from 7.0 to 7.7 mag, where the 7.0 is EXCLUDED
-    - 2 faint (but OK) stars 10.0, 10.1 where the 10.0 is INCLUDED
-    - 1 very faint (bad) stars 12.0 mag is INCLUDED
-
-    Both the 7.0 and 10.1 would normally get picked either initially
-    or swapped in during optimization, and 12.0 would never get picked.
+    Test include and exclude fids.
     """
     fids = get_fid_catalog(stars=StarsTable.empty(), dark=DARK40, **STD_INFO)
     assert np.all(fids['id'] == [2, 4, 5])

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -257,11 +257,11 @@ def test_fids_include_bad():
     # Define includes and excludes.
     include_ids = [10]
     exclude_ids = []
-    fids = get_fid_catalog(stars=StarsTable.empty(), dark=DARK40, **STD_INFO,
-                           include_ids=include_ids, exclude_ids=exclude_ids)
 
-    # If you force-include a non-existent fid, you get nothing
-    assert len(fids) == 0
+    # If you force-include a non-existent fid, you raise ValueError
+    with pytest.raises(ValueError):
+        get_fid_catalog(stars=StarsTable.empty(), dark=DARK40, **STD_INFO,
+                        include_ids=include_ids, exclude_ids=exclude_ids)
 
     # Set up a scenario with large offset so only two are on the CCD
     include_ids = [4]
@@ -273,5 +273,7 @@ def test_fids_include_bad():
     fids = get_fid_catalog(**mod_std_info(stars=StarsTable.empty(), sim_offset=80000),
                            include_ids=include_ids, exclude_ids=exclude_ids)
 
-    # If you force-include a fid that is off the CCD no sets match and you get nothing
-    assert len(fids) == 0
+    assert np.all(fids['id'] == [1, 2, 4])
+
+    # If you force-include a fid that is off the CCD, it is still off the CCD
+    assert fids.off_ccd(fids.get_id(4))


### PR DESCRIPTION
## Description

Add include/exclude of fids by index/id

I went with the strategy of using the included or excluded ids to reduce the candidate fid sets at the beginning of the fid selection.  If an impossible fid is requested, no candidates will remain and no fids will be selected.  This seemed reasonable for the use cases (though may not work to manually select fid sets used in previous undercover observations with off-CCD fids).

## Testing

- [x] Passes unit tests Linux
- [X] Added tests for functional testing
