### PR TITLE
Fix inadvertent re-use of base class `allowed_kwargs`

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Lint with flake8
       run: |
         pip install flake8
-        flake8 . --count --exclude=docs/conf.py --ignore=W504,E402,F541 --max-line-length=100 --show-source --statistics
+        flake8 . --count --exclude=docs/conf.py --ignore=W503,W504,E402,F541 --max-line-length=100 --show-source --statistics

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -117,6 +117,10 @@ class AcqTable(ACACatalogTable):
     """
     Catalog of acquisition stars
     """
+    # Define base set of allowed keyword args to __init__. Subsequent MetaAttribute
+    # or AliasAttribute properties will add to this.
+    allowed_kwargs = ACACatalogTable.allowed_kwargs.copy()
+
     # Catalog type when plotting (None | 'FID' | 'ACQ' | 'GUI')
     catalog_type = 'ACQ'
 

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -182,6 +182,10 @@ class ACATable(ACACatalogTable):
     as attributes and other methods relevant to the merged catalog.
 
     """
+    # Define base set of allowed keyword args to __init__. Subsequent MetaAttribute
+    # or AliasAttribute properties will add to this.
+    allowed_kwargs = ACACatalogTable.allowed_kwargs.copy()
+
     optimize = MetaAttribute(default=True)
     call_args = MetaAttribute(default={})
     version = MetaAttribute()

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -610,7 +610,10 @@ class ACACatalogTable(BaseCatalogTable):
 
     def set_attrs_from_kwargs(self, **kwargs):
         for name, val in kwargs.items():
-            if name in self.allowed_kwargs:
+            # If name is an allowed keyword arg or a settable property on the class
+            # then set now.
+            if (name in self.allowed_kwargs
+                    or inspect.isdatadescriptor(getattr(self.__class__, name, None))):
                 setattr(self, name, val)
             else:
                 raise ValueError(f'unexpected keyword argument "{name}"')

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -74,6 +74,10 @@ def get_fid_catalog(obsid=0, **kwargs):
 
 
 class FidTable(ACACatalogTable):
+    # Define base set of allowed keyword args to __init__. Subsequent MetaAttribute
+    # or AliasAttribute properties will add to this.
+    allowed_kwargs = ACACatalogTable.allowed_kwargs | set(['acqs'])
+
     # Catalog type when plotting (None | 'FID' | 'ACQ' | 'GUI')
     catalog_type = 'FID'
 
@@ -83,8 +87,6 @@ class FidTable(ACACatalogTable):
 
     cand_fids = MetaAttribute(is_kwarg=False)
     cand_fid_sets = MetaAttribute(is_kwarg=False)
-
-    allowed_kwargs = ACACatalogTable.allowed_kwargs | set(['acqs'])
 
     required_attrs = ('att', 'detector', 'sim_offset', 'focus_offset',
                       't_ccd_guide', 'date',

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -69,6 +69,10 @@ def get_guide_catalog(obsid=0, **kwargs):
 
 
 class GuideTable(ACACatalogTable):
+    # Define base set of allowed keyword args to __init__. Subsequent MetaAttribute
+    # or AliasAttribute properties will add to this.
+    allowed_kwargs = ACACatalogTable.allowed_kwargs | set(['fids'])
+
     # Catalog type when plotting (None | 'FID' | 'ACQ' | 'GUI')
     catalog_type = 'GUI'
 
@@ -79,8 +83,6 @@ class GuideTable(ACACatalogTable):
     # Name of table.  Use to define default file names where applicable.
     # (e.g. `obs19387/guide.pkl`).
     name = 'guide'
-
-    allowed_kwargs = ACACatalogTable.allowed_kwargs | set(['fids'])
 
     # Required attributes
     required_attrs = ('att', 't_ccd_guide', 'date', 'dither_guide', 'n_guide')

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -14,13 +14,22 @@ import numpy as np
 import mica.starcheck
 
 from .test_common import STD_INFO, mod_std_info, DARK40, OBS_INFO
-from ..core import StarsTable, includes_for_obsid
+from ..core import StarsTable, includes_for_obsid, ACACatalogTable
 from ..catalog import get_aca_catalog, ACATable
-from ..fid import get_fid_catalog
+from ..fid import get_fid_catalog, FidTable
 from .. import characteristics as ACA
 
 HAS_SC_ARCHIVE = Path(mica.starcheck.starcheck.FILES['data_root']).exists()
 TEST_COLS = 'slot idx id type sz yang zang dim res halfw'.split()
+
+
+def test_allowed_kwargs():
+    """Test #332 where allowed_kwargs class attribute is unique for each subclass"""
+    new_kwargs = ACATable.allowed_kwargs - ACACatalogTable.allowed_kwargs
+    assert new_kwargs == {'call_args', 'version'}
+
+    new_kwargs = FidTable.allowed_kwargs - ACACatalogTable.allowed_kwargs
+    assert new_kwargs == {'acqs'}
 
 
 @pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')


### PR DESCRIPTION
## Description

This fixes #330, primarily by 82b3910 which allows setting something that is a class property even if it is not in the `allowed_kwargs` set.

However, along the way I discovered a more serious problem which was that the class inheritance from `ACACatalogTable` was re-using (for FidTable and ACATable) the base class `allowed_kwargs`. This was the source of the ordering issue in #330 because `FidTable` was trying to set `t_ccd` but relying on `t_ccd` showing up in `allowed_kwargs` because of importing `catalog` (which defined `ACACatalogTable` and added `t_ccd` to `allowed_kwargs`). So I fixed this problem by making sure each class has a private copy of `allowed_kwargs`.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing : TO DO add a new unit test.

Fixes #330 