### PR TITLE
Remove defunct thumbs_up property

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -147,21 +147,6 @@ attributes::
   37879960 188.579307 2.444460  -567.34  -632.27  119.53 ...   10.70 0.000     1     1    25  6x6
   37882072 188.584100 1.455829  2197.62  1608.89 -436.73 ...   11.66 0.000     1     1    25  6x6
 
-The ``aca`` object provides a ``thumbs_up`` attribute which is
-a rough indicator that the catalog will likely pass or fail ACA review.
-The value of this is ``0`` for NOT OK and ``1`` for OK.  Note in
-this case that too few guide stars have been selected::
-
-  >>> aca.thumbs_up
-  0
-
-  >>> aca.acqs.thumbs_up
-  1
-  >>> aca.guides.thumbs_up
-  0
-  >>> aca.fids.thumbs_up
-  1
-
 Each of the individual catalogs also has a ``warnings`` attribute that is a
 list of any warnings which occurred in processing::
 

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -194,17 +194,6 @@ class AcqTable(ACACatalogTable):
         self.update_p_acq_column(self)
         self.calc_p_safe()
 
-    @property
-    def thumbs_up(self):
-        if self.n_acq == 0:
-            out = 1
-        elif len(self) < 2:
-            out = 0
-        else:
-            self.update_p_acq_column(self)
-            out = int(self.get_log_p_2_or_fewer() <= np.log10(ACQ.acq_prob))
-        return out
-
     def make_report(self, rootdir='.'):
         """
         Make summary HTML report for acq selection process and outputs.

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -220,12 +220,6 @@ class ACATable(ACACatalogTable):
         out.guides = GuideTable.empty()
         return out
 
-    @property
-    def thumbs_up(self):
-        return int(self.acqs.thumbs_up &
-                   self.fids.thumbs_up &
-                   self.guides.thumbs_up)
-
     def set_attrs_from_kwargs(self, **kwargs):
         """Set object attributes from kwargs.
 

--- a/proseco/characteristics_acq.py
+++ b/proseco/characteristics_acq.py
@@ -48,10 +48,6 @@ man_errs = p_man_errs['man_err_hi']
 # Minimal set of columns to store for spoiler stars
 spoiler_star_cols = ['id', 'yang', 'zang', 'row', 'col', 'mag', 'mag_err']
 
-# Minimum acquisition probability thresholds from starcheck for thumbs_up
-acq_prob_n = 2
-acq_prob = 8e-3
-
 
 def _get_fid_acq_stages():
     fid_acqs = Table.read("""

--- a/proseco/characteristics_guide.py
+++ b/proseco/characteristics_guide.py
@@ -6,9 +6,6 @@ fid_trap = {'row': -374,
             'col': 347,
             'margin': 8}
 
-# Minimum scaled guide count for thumbs_up
-min_guide_count = 4.0
-
 # Add this padding to region checked for bad pixels (in addition to dither)
 dither_pix_pad = 0.4
 

--- a/proseco/fid.py
+++ b/proseco/fid.py
@@ -116,17 +116,6 @@ class FidTable(ACACatalogTable):
     def t_ccd(self, value):
         self.t_ccd_guide = value
 
-    @property
-    def thumbs_up(self):
-        if self.n_fid == 0:
-            out = 1
-        elif len(self) == 0:
-            out = 0
-        else:
-            out = int(len(self) == self.n_fid and  # Requested number of fids
-                      self['spoiler_score'].sum() < 4)  # No red fid warnings
-        return out
-
     def set_fid_set(self, fid_ids):
         if len(self) > 0:
             self.remove_rows(np.arange(len(self)))

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -100,19 +100,6 @@ class GuideTable(ACACatalogTable):
     include_ids = AliasAttribute()
     exclude_ids = AliasAttribute()
 
-    @property
-    def thumbs_up(self):
-        if self.n_guide == 0:
-            # If no guides were requested then always OK
-            out = 1
-        elif len(self) == 0:
-            out = 0
-        else:
-            # Evaluate guide catalog quality for thumbs_up
-            count = guide_count(self['mag'], self.t_ccd)
-            out = int(count >= GUIDE.min_guide_count)
-        return out
-
     def make_report(self, rootdir='.'):
         """
         Make summary HTML report for guide selection process and outputs.

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -8,7 +8,6 @@ import chandra_aca.aca_image
 from chandra_aca.transform import (mag_to_count_rate, count_rate_to_mag,
                                    snr_mag_for_t_ccd)
 from chandra_aca.aca_image import ACAImage, AcaPsfLibrary
-from chandra_aca.star_probs import guide_count
 
 from . import characteristics as ACA
 from . import characteristics_guide as GUIDE


### PR DESCRIPTION
## Description

The thumbs-up concept has been replaced by sparkles and it is no longer used.

Need to verify that this is also not used in MATLAB tools ORviewer. An old version that we have in our repo appears to use this:

https://github.com/sot/fot_matlab_tools/blob/0fd5ab5f0afb019c06df4a979f247eb8d7f697bf/MissionScheduling/stars/StarSelector/%40StarSelector/private/getProsecoCatalog.m#L59

## Testing

- [x] Passes unit tests on MacOS
- [N/A] Functional testing from Matlab Tools: functional testing deferred to the next MATLAB release.

Closes #202 
Closes #275 