### PR TITLE
Fix allowed_kwargs test after #331

### DIFF
--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -29,7 +29,7 @@ def test_allowed_kwargs():
     assert new_kwargs == {'call_args', 'version'}
 
     new_kwargs = FidTable.allowed_kwargs - ACACatalogTable.allowed_kwargs
-    assert new_kwargs == {'acqs'}
+    assert new_kwargs == {'acqs', 'include_ids', 'exclude_ids'}
 
 
 @pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')


### PR DESCRIPTION
## Description

Fix allowed_kwargs test after #331

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [N/A] Functional testing

Fixes #342 