### PR TITLE
Fix problem from table API change in astropy 4.2

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -56,7 +56,7 @@ def get_guide_catalog(obsid=0, **kwargs):
     selected = guides.run_search_stages()
 
     # Transfer to table (which at this point is an empty table)
-    guides.add_columns(selected.columns.values())
+    guides.add_columns(list(selected.columns.values()))
 
     guides['idx'] = np.arange(len(guides))
 


### PR DESCRIPTION
## Description

Same changes applied on a branch (PR #350).

Between astropy 4.0 and 4.2 there was an API change in the `Table.columns` class where `Table.columns.values()` went from being a list to being `odict_values` (like a generator).

This fixes a problem noted in integration testing for the Ska3 2021.2 release.

## Testing

- [x] Passes unit tests on MacOS
- [N/A] Functional testing


Fixes #