### PR TITLE
WIP: Save agasc supplement info in meta

### DIFF
--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -131,6 +131,12 @@ def _get_aca_catalog(**kwargs):
     if hasattr(aca.acqs, 'dark_date'):
         aca.dark_date = aca.acqs.dark_date
 
+    # Store the agasc supplement meta info if available
+    if hasattr(aca.stars, 'supp_agasc_version'):
+        aca.supp_agasc_version = aca.stars.supp_agasc_version
+    if hasattr(aca.stars, 'supp_last_updated'):
+        aca.supp_last_updated = aca.stars.supp_last_updated
+
     # Note that aca.acqs.stars is a filtered version of aca.stars and includes
     # only stars that are in or near ACA FOV.  Use this for fids and guides stars.
     aca.log('Starting get_fid_catalog')

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -2,6 +2,7 @@
 import copy
 import os
 
+from distutils.version import LooseVersion
 import matplotlib
 from Quaternion import Quat
 
@@ -11,6 +12,7 @@ import pickle
 import pytest
 from pathlib import Path
 
+from cxotime import CxoTime
 import numpy as np
 import mica.starcheck
 import agasc
@@ -68,6 +70,11 @@ def test_get_aca_catalog_20603_with_supplement():
             or np.any(aca_no.guides['mag'] != aca.guides['mag']))
     assert (len(aca_no.acqs) != len(aca.acqs)
             or np.any(aca_no.acqs['mag'] != aca.acqs['mag']))
+
+    assert LooseVersion(aca.supp_agasc_version) > LooseVersion('4.10')
+    assert CxoTime(aca.supp_last_updated) > CxoTime('2021-03-01')
+
+    assert aca_no.supp_agasc_version is None
 
 
 @pytest.mark.skipif(not HAS_SC_ARCHIVE, reason='Test requires starcheck archive')


### PR DESCRIPTION
## Description

Save the agasc supplement info in the meta for a catalog if the supplement data was used.

## Testing

- [x] Passes unit tests on linux
- [x] Functional testing - new simple asserts added to existing test
