### PR TITLE
Add region of diminshed CCD response to bad_pixels

### DIFF
--- a/proseco/characteristics.py
+++ b/proseco/characteristics.py
@@ -38,8 +38,13 @@ bad_pixel_dark_current = 700_000
 
 # Bad pixels.
 # Fid trap: http://cxc.cfa.harvard.edu/mta/ASPECT/aca_weird_pixels/
+# Diminished response: https://chandramission.slack.com/archives/G01LN40AXPG/p1624543385000700
+#   and subsequent discussion in nearby aspect-team threads.
+#             [row0 row1 col0 col1] (where values are inclusive on both ends)
 bad_pixels = [[-245, 0, 454, 454],  # Bad column
-              [-374, -374, 347, 347]]  # Fid trap
+              [-374, -374, 347, 347],  # Fid trap
+              [-319, -317, -299, -296]  # Diminished response
+              ]
 
 
 def _load_bad_star_set():

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -781,7 +781,9 @@ def test_acq_fid_catalog_probs_low_level():
     aca = get_aca_catalog(**kwargs)
     acqs = aca.acqs
 
-    assert np.all(acqs.dark[0:512, 0:512] == 40)
+    # Check that vast majority of pixels are 40. The rest are bad pixels set to
+    # 700_000.
+    assert np.percentile(acqs.dark, 99.95) == 40.0
 
     # Initial fid set is empty () and we check baseline p_safe
     assert acqs.fid_set == ()


### PR DESCRIPTION
## Description

Add a region of CCD pixels that appear to be associated with diminished response in the CCD. This is the proseco analog of the starcheck update https://github.com/sot/starcheck/pull/373.

## Testing

- [x] Passes unit tests on MacOS : one test failing right now.
- [x] Functional testing

### Functional testing
 
Ran star selection for obsids 48040 and 22957. Confirmed that with the patch in place, the stars which originally dithered over the bad region were not selected. Confirmed that without the patch those stars were selected as BOT.