### PR TITLE
Pass catalog date to plotting so planets are drawn

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -760,6 +760,8 @@ class ACACatalogTable(BaseCatalogTable):
             self.set_stars()
         kwargs.setdefault('stars', self.stars)
         kwargs.setdefault('bad_stars', self.bad_stars_mask)
+        if self.date is not None:
+            kwargs.setdefault('starcat_time', self.date)
         return super().plot(ax, **kwargs)
 
     @property


### PR DESCRIPTION
## Description

This goes along with https://github.com/sot/chandra_aca/pull/116 to improve plotting of planets for a proseco catalog. 

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing 
```
from proseco import get_aca_catalog
aca = get_aca_catalog(22159)
aca.plot()
```
<img src="https://user-images.githubusercontent.com/348089/124808008-69b5a880-df2c-11eb-82cc-6f389b7d5c6f.png" width=400>
