### PR TITLE
Set catalog n_guide appropriately in case of mon windows

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ obsid         obsid (default=0)
 att           attitude (any object that can initialize Quat)
 n_acq         desired number of acquisition stars (default=8)
 n_fid         desired number of fid lights (req'd unless obsid spec'd)
-n_guide       desired number of guide stars (req'd unless obsid spec'd)
+n_guide       desired number of guide stars + monitor windows (see note below)
 man_angle     maneuver angle (deg)
 t_ccd_acq     ACA CCD temperature for acquisition (degC)
 t_ccd_guide   ACA CCD temperature for guide (degC)
@@ -69,6 +69,16 @@ t_ccd_eff_acq       ACA CCD effective temperature for acquisition (degC)
 t_ccd_eff_guide     ACA CCD effective temperature for guide (degC)
 dark_date           date of dark cal
 =================== =================================================================
+
+The input ``n_guide`` parameter represents the number of slots available for the
+combination of guide stars and monitor windows (including both fixed and
+tracking monitor windows). In most normal situations, ``n_guide`` is equal to
+``8 - n_fid``. The ``n_guide`` parameter is confusingly named but this is
+because the actual number of guide stars is not known in advance in the case of
+auto-conversion from a monitor request to a guide star. In actual practice,
+what is normally known is how many slots are available for the combination of
+guide stars and monitor windows, so this makes the call to catalog creation
+simpler.
 
 Within the ``include_halfws_acq`` list, one can supply the value ``0`` for a
 star instead of a typical legal value such as ``60`` or ``120``.  In that case

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -51,6 +51,16 @@ def get_aca_catalog(obsid=0, **kwargs):
     appending this string, e.g. with ``obs_text + '--force-catalog'`` in the
     call to ``get_aca_catalog``.
 
+    The input ``n_guide`` parameter represents the number of slots available for
+    the combination of guide stars and monitor windows (including both fixed and
+    tracking monitor windows). In most normal situations, ``n_guide`` is equal
+    to ``8 - n_fid``. The ``n_guide`` parameter is confusingly named but this is
+    because the actual number of guide stars is not known in advance in the case
+    of auto-conversion from a monitor request to a guide star. In actual
+    practice, what is normally known is how many slots are available for the
+    combination of guide stars and monitor windows, so this makes the call to
+    catalog creation simpler.
+
     NOTE on API:
 
     Keywords that have ``_acq`` and/or ``_guide`` suffixes are handled with
@@ -63,7 +73,7 @@ def get_aca_catalog(obsid=0, **kwargs):
     :param att: attitude (any object that can initialize Quat)
     :param n_acq: desired number of acquisition stars (default=8)
     :param n_fid: desired number of fid lights (req'd unless obsid spec'd)
-    :param n_guide: desired number of guide stars (req'd unless obsid spec'd)
+    :param n_guide: desired number of guide stars + monitor windows (req'd unless obsid spec'd)
     :param monitors: N x 5 float array specifying monitor windows
     :param man_angle: maneuver angle (deg)
     :param t_ccd_acq: ACA CCD temperature for acquisition (degC)

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -199,6 +199,12 @@ def _get_aca_catalog(**kwargs):
     aca.guides = get_guide_catalog(stars=aca.acqs.stars, fids=aca.fids, mons=aca.mons,
                                    img_size=img_size_guide, **kwargs)
 
+    # Set output catalog aca.n_guide to reflect what the number of requested
+    # guide stars as determined in guide star selection processing. The input
+    # arg value of n_guide (which initially defines aca.n_guide) reflects the
+    # requested number of available slots for guide + monitor stars / windows.
+    aca.n_guide = aca.guides.n_guide
+
     # Make a merged starcheck-like catalog.  Catch any errors at this point to avoid
     # impacting operational work (call from Matlab).
     try:
@@ -278,6 +284,7 @@ def _get_aca_catalog_monitors(**kwargs):
     # If there are no new critical messages then schedule as guide star(s).
     # This checks that every critical in crit_gui is also in crits_mon.
     out = aca_gui if crits_gui <= crits_mon else aca_mon
+
     return out
 
 

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -209,10 +209,11 @@ def _get_aca_catalog(**kwargs):
     aca.guides = get_guide_catalog(stars=aca.acqs.stars, fids=aca.fids, mons=aca.mons,
                                    img_size=img_size_guide, **kwargs)
 
-    # Set output catalog aca.n_guide to reflect what the number of requested
-    # guide stars as determined in guide star selection processing. The input
-    # arg value of n_guide (which initially defines aca.n_guide) reflects the
-    # requested number of available slots for guide + monitor stars / windows.
+    # Set output catalog aca.n_guide to the number of requested guide stars as
+    # determined in guide star selection processing. This differs from the input
+    # arg value of n_guide which is (confusingly) the number of available slots
+    # for guide + monitor stars / windows. Thus if the input n_guide is set to
+    # 5 and there is a monitor window then aca.n_guide will be 4.
     aca.n_guide = aca.guides.n_guide
 
     # Make a merged starcheck-like catalog.  Catch any errors at this point to avoid

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -151,9 +151,9 @@ class GuideTable(ACACatalogTable):
             row, col = int(monitor['row']) + 512, int(monitor['col']) + 512
             self.dark[row-dr: row+dr, col-dc: col+dc] = ACA.bad_pixel_dark_current  # noqa
 
-            # Temporarily reduce n_guide for each MON. Globally n_guide is the
+            # Reduce n_guide for each MON. On input the n_guide arg is the
             # number of GUI + MON, but for guide selection we need to make the
-            # MON slots unavailable. This reduction gets undone in post.
+            # MON slots unavailable.
             self.n_guide -= 1
             if self.n_guide < 2:
                 raise ValueError('too many MON requests leaving < 2 guide stars')

--- a/proseco/tests/test_mon_full_cat.py
+++ b/proseco/tests/test_mon_full_cat.py
@@ -84,6 +84,7 @@ def test_monitor_mon_fixed_auto():
            '   6  13    134680  ACQ 6x6  1314.00  1085.73  28   1   160']
 
     assert aca[TEST_COLS].pformat_all() == exp
+    assert aca.n_guide == 4  # Two of 6 guide slots become MON slots
 
     mon = aca.get_id(1000, mon=True)
     assert mon['dim'] == mon['slot']  # Fixed MON
@@ -141,6 +142,7 @@ def test_full_catalog():
            '   5  11 100008  ACQ 6x6   400.00   400.00   8   1    60 10.50']
 
     assert aca[TEST_COLS + ['mag']].pformat_all() == exp
+    assert aca.n_guide == 6  # One of 7 available guide slots becomes a MON
 
 
 def test_mon_takes_guide():
@@ -173,3 +175,4 @@ def test_mon_takes_guide():
            '   4   6 100000  ACQ 8x8  1500.00     0.00  28   1   160  6.50']
 
     assert aca[TEST_COLS + ['mag']].pformat_all() == exp
+    assert aca.n_guide == 4  # One of 5 available guide slots becomes a MON


### PR DESCRIPTION
## Description

When getting a catalog via `aca = get_aca_catalog(...)`, the `aca.n_guide` attribute now reflects the input `n_guide` minus the number of scheduled monitor windows. This is effectively the number of requested guide stars, accounting for the possibility of monitor stars that are auto-converted from MON to GUI.

To clarify with an example, if `n_guide=5` and a `monitors` arg is provided with the position the target which happens to be a nice 8th mag star in the AGASC suitable for guiding, and the monitor function is `AUTO`, then `aca.n_guide` will be `5` and `aca.mons` will be an empty table. 

However, if that target is a 12th mag star which is not suitable for guiding, then `aca.n_guide` will be `4` and `aca.mons` will have one entry with a tracking monitor window.

## Testing

- [x] Passes unit tests on MacOS (with new tests)
- [n/a] Functional testing