### PR TITLE
Copy back the original kwargs into the monitor catalog call args

### DIFF
--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -274,6 +274,7 @@ def _get_aca_catalog_monitors(**kwargs):
 
     # Get the catalog and do a sparkles review
     aca_mon = _get_aca_catalog(**kwargs)
+    aca_mon.call_args = kwargs_orig.copy()  # Needed for roll optimization, see #364
     acar_mon = aca_mon.get_review_table()
     acar_mon.run_aca_review()
     crits_mon = set(msg['text'] for msg in (acar_mon.messages >= 'critical'))
@@ -283,16 +284,15 @@ def _get_aca_catalog_monitors(**kwargs):
     kwargs['raise_exc'] = True
     try:
         aca_gui = _get_aca_catalog(**kwargs)
+        aca_gui.call_args = kwargs_orig.copy()  # Needed for roll optimization, see #364
     except BadMonitorError as exc:
         aca_mon.log(f'unable to convert monitor to guide: {exc}')
-        aca_mon.call_args = kwargs_orig.copy()
         return aca_mon
 
     # Get the catalog and do a sparkles review
     acar_gui = aca_gui.get_review_table()
     acar_gui.run_aca_review()
     crits_gui = set(msg['text'] for msg in (acar_gui.messages >= 'critical'))
-    aca_gui.call_args = kwargs_orig.copy()
 
     # If there are no new critical messages then schedule as guide star(s).
     # This checks that every critical in crit_gui is also in crits_mon.

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -285,12 +285,14 @@ def _get_aca_catalog_monitors(**kwargs):
         aca_gui = _get_aca_catalog(**kwargs)
     except BadMonitorError as exc:
         aca_mon.log(f'unable to convert monitor to guide: {exc}')
+        aca_mon.call_args = kwargs_orig.copy()
         return aca_mon
 
     # Get the catalog and do a sparkles review
     acar_gui = aca_gui.get_review_table()
     acar_gui.run_aca_review()
     crits_gui = set(msg['text'] for msg in (acar_gui.messages >= 'critical'))
+    aca_gui.call_args = kwargs_orig.copy()
 
     # If there are no new critical messages then schedule as guide star(s).
     # This checks that every critical in crit_gui is also in crits_mon.


### PR DESCRIPTION
## Description

Copy back the original kwargs into the monitor catalog call args

The ACACatalogTable object should have the original arguments and not any arguments that were used just to determine if the monitor window should be a MON or a guide-from-mon, and this change assures that.

## Testing

- [x] Passes unit tests on linux
- [x] Functional testing - new test added in https://github.com/sot/sparkles/pull/156

Fixes #364 