### PR TITLE
Improve handling for missing required args

### DIFF
--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -332,6 +332,11 @@ class ACATable(ACACatalogTable):
     # or AliasAttribute properties will add to this.
     allowed_kwargs = ACACatalogTable.allowed_kwargs.copy()
 
+    required_attrs = ('att', 'n_fid', 'n_guide', 'man_angle',
+                      't_ccd_acq', 't_ccd_guide',
+                      'dither_acq', 'dither_guide', 'date',
+                      'detector')
+
     optimize = MetaAttribute(default=True)
     call_args = MetaAttribute(default={})
     version = MetaAttribute()

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -162,8 +162,18 @@ def test_exception_handling():
 
 
 def test_unhandled_exception():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError, match=r'missing required parameters'):
+        # TypeError in get_starcheck_catalog due to NoneType obsid
         get_aca_catalog(obsid=None, raise_exc=True)
+
+    with pytest.raises(ValueError, match=r'missing required parameters'):
+        # Obsid 0 implies all all pars must be provided
+        get_aca_catalog(obsid=0, raise_exc=True)
+
+    with pytest.raises(ValueError, match=r'missing required parameters'):
+        # Obsid > 0 implies missing pars are to be found in starcheck archive,
+        # but this one will certainly not be found.
+        get_aca_catalog(obsid=99999, raise_exc=True)
 
 
 def test_no_candidates():


### PR DESCRIPTION
## Description

In the course of investigating the sparkles failure from https://github.com/sot/sparkles/pull/159, I noticed that the handling of missing required arguments could be improved.

This update catches exceptions in a likely place and provides a more useful error message.

## Testing

- [x] Passes unit tests on MacOS (with new tests)
- [x] Functional testing

### Functional testing

Ran the new exception cases in IPython and confirmed the expected exception chain for the obsid=99999 case.