### PR TITLE
Add duration and target_name attributes to ACACatalog

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,8 @@ detector      'ACIS-S' | 'ACIS-I' | 'HRC-S' | 'HRC-I'
 =================== =================================================================
 Argument            Description
 =================== =================================================================
+target_name         Target name, e.g. from the OR list (str)
+duration            Observation duration (secs)
 sim_offset          SIM translation offset from nominal [steps] (default=0)
 focus_offset        SIM focus offset [steps] (default=0)
 target_offset       target offset including dynamical offset (y, z, deg)

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -154,11 +154,6 @@ def _get_aca_catalog(**kwargs):
     aca.call_args = kwargs.copy()
     aca.version = VERSION
 
-    # Remove kwargs that are specific to AcaTable
-    for kwarg in ('t_ccd', 't_ccd_penalty_limit', 'duration', 'target_name'):
-        if kwarg in kwargs:
-            del kwargs[kwarg]
-
     # Override t_ccd related inputs with effective temperatures for downstream
     # action by AcqTable, GuideTable, FidTable.  See set_attrs_from_kwargs()
     # - t_ccd_eff_{acq,guide} are the effective T_ccd values which are adjusted
@@ -177,7 +172,8 @@ def _get_aca_catalog(**kwargs):
 
     # These are allowed inputs to get_aca_catalog but should not be passed to
     # get_{acq,guide,fid}_catalog. Pop them from kwargs.
-    for kwarg in ('t_ccd', 't_ccd_eff_acq', 't_ccd_eff_guide', 'stars'):
+    for kwarg in ('t_ccd', 't_ccd_eff_acq', 't_ccd_eff_guide', 'stars',
+                  't_ccd_penalty_limit', 'duration', 'target_name'):
         kwargs.pop(kwarg, None)
 
     # Get stars (typically from AGASC) and do not filter for stars near

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -82,6 +82,8 @@ def get_aca_catalog(obsid=0, **kwargs):
         provided this defaults to value from the ACA xija thermal model.
     :param t_ccd_eff_acq: ACA CCD effective temperature for acquisition (degC)
     :param t_ccd_eff_guide: ACA CCD effective temperature for guide (degC)
+    :param duration: duration of observation (sec)
+    :param target_name: name of target (str)
     :param date: date of acquisition (any DateTime-compatible format)
     :param dither_acq: acq dither size (2-element sequence (y, z), arcsec)
     :param dither_guide: guide dither size (2-element sequence (y, z), arcsec)
@@ -153,7 +155,7 @@ def _get_aca_catalog(**kwargs):
     aca.version = VERSION
 
     # Remove kwargs that are specific to AcaTable
-    for kwarg in ('t_ccd', 't_ccd_penalty_limit'):
+    for kwarg in ('t_ccd', 't_ccd_penalty_limit', 'duration', 'target_name'):
         if kwarg in kwargs:
             del kwargs[kwarg]
 
@@ -339,6 +341,10 @@ class ACATable(ACACatalogTable):
     # For validation with get_aca_catalog(obsid), store the starcheck
     # catalog in the ACATable meta.
     starcheck_catalog = MetaAttribute(is_kwarg=False)
+
+    # Observation information
+    duration = MetaAttribute()
+    target_name = MetaAttribute()
 
     # Effective T_ccd used for dynamic ACA limits (see updates_for_t_ccd_effective()
     # method below).

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -762,6 +762,8 @@ class ACACatalogTable(BaseCatalogTable):
         kwargs.setdefault('bad_stars', self.bad_stars_mask)
         if self.date is not None:
             kwargs.setdefault('starcat_time', self.date)
+        if getattr(self, 'duration', None) is not None:
+            kwargs.setdefault('duration', self.duration)
         return super().plot(ax, **kwargs)
 
     @property

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -34,7 +34,7 @@ def test_allowed_kwargs():
     """Test #332 where allowed_kwargs class attribute is unique for each subclass"""
     new_kwargs = ACATable.allowed_kwargs - ACACatalogTable.allowed_kwargs
     assert new_kwargs == {'call_args', 'version', 't_ccd_eff_acq', 't_ccd_eff_guide',
-                          't_ccd_penalty_limit'}
+                          't_ccd_penalty_limit', 'duration', 'target_name'}
 
     new_kwargs = FidTable.allowed_kwargs - ACACatalogTable.allowed_kwargs
     assert new_kwargs == {'acqs', 'include_ids', 'exclude_ids'}
@@ -324,13 +324,18 @@ def test_big_sim_offset():
     """
     Check getting a catalog for a large SIM offset that means there are
     no candidates.
+
+    Bonus: check that duration and target_name can be set.
     """
-    aca = get_aca_catalog(**mod_std_info(sim_offset=200000, raise_exc=True))
+    aca = get_aca_catalog(**mod_std_info(sim_offset=200000, duration=10000,
+                                         target_name='Target Name', raise_exc=True))
     assert len(aca.acqs) == 8
     assert len(aca.guides) == 5
     assert len(aca.fids) == 0
     names = ['id', 'yang', 'zang', 'row', 'col', 'mag', 'spoiler_score', 'idx']
     assert all(name in aca.fids.colnames for name in names)
+    assert aca.duration == 10000
+    assert aca.target_name == 'Target Name'
 
 
 @pytest.mark.parametrize('call_t_ccd', [True, False])


### PR DESCRIPTION
## Description

Add `duration` and `target_name` as optional attributes to the `ACACatalog` class.

The new `duration` arg is passed to the plot call if set. Nothing is currently done with `target_name` but the plan is to include it in the sparkles report if available.

## Testing

- [x] Passes unit tests on MacOS (with new test)
- [x] Functional testing

### Functional testing
```
from proseco import get_aca_catalog

kwargs = {
 'att': [-0.4996202990573842, 0.25613539728653284, -0.16663867795479226, 0.8105589220014537],
 'date': '2021:251:11:34:28.238',
 'target_name': 'Jupiter',
 'detector': 'HRC-S',
 'dither_acq': (7.9992, 7.9992),
 'dither_guide': (7.9992, 7.9992),
 'focus_offset': -70.0,
 'man_angle': 107.4907328663431,
 'n_acq': 8,
 'n_fid': 3,
 'n_guide': 5,
 'obsid': 23366.0,
 'sim_offset': 0.0,
 't_ccd_acq': -11.961137803591706,
 't_ccd_guide': -11.973059091097342,
 't_ccd_penalty_limit': -6.8}

# Without duration, makes a plot that shows Jupiter but at just the start time
aca = get_aca_catalog(**kwargs)
aca.plot()

# With the duration, makes a plot that shows Jupiter over 36 ks
aca = get_aca_catalog(duration=36000, **kwargs)
aca.plot()

# Sparkles report shows the track of Jupiter over 36 ks
acar = aca.get_review_table()
acar.run_aca_review(make_html=True, report_dir='test_duration')
```

Fixes #362 