### PR TITLE
Exclude guide star if it overlaps with brighter/better guide star

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -290,7 +290,7 @@ class GuideTable(ACACatalogTable):
     def exclude_overlaps(self, stage_cands):
         """
         Review the stars selected at any stage and exclude stars that overlap in
-        tracking space with another. Overlap is defined as 60 arcsecs in Y and Z.
+        tracking space with another. Overlap is defined as being within 12 pixels.
         """
         self.log(f'Checking for guide star overlap in stage-selected stars')
         nok = np.zeros(len(stage_cands)).astype(bool)
@@ -306,16 +306,19 @@ class GuideTable(ACACatalogTable):
                 # Check and exclude a guide star only if it would spoil a lower index (better) star.
                 if idx <= jdx:
                     continue
-                dy = other_star['yang'] - star['yang']
-                dz = other_star['zang'] - star['zang']
-                if np.abs(dy) < 60 and np.abs(dz) < 60:
+                drow = other_star['row'] - star['row']
+                dcol = other_star['col'] - star['col']
+                if np.abs(drow) <= 12 and np.abs(dcol) <= 12:
                     self.log(
-                        f"Rejected star {star['id']} as has track overlap with {other_star['id']}")
+                        f"Rejecting star {star['id']} with track overlap (12 pixels) "
+                        f"with star {other_star['id']}")
                     self.reject(
                         {'id': star['id'],
                          'type': 'overlap',
                          'stage': 0,
-                         'text': f'Cand {star["id"]} has track overlap with {other_star["id"]}'})
+                         'text':
+                         f'Cand {star["id"]} has track overlap (12 pixels) '
+                         f'with star {other_star["id"]}'})
                     nok[idx] = True
         return stage_cands[~nok]
 

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -296,6 +296,9 @@ class GuideTable(ACACatalogTable):
         nok = np.zeros(len(stage_cands)).astype(bool)
         for idx, star in enumerate(stage_cands):
             for jdx, other_star in enumerate(stage_cands):
+
+                # The stage_cands are supplied in the order of preference (currently by mag)
+                # Check and exclude a guide star only if it would spoil a lower index (better) star.
                 if idx <= jdx:
                     continue
                 dy = other_star['yang'] - star['yang']

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -295,6 +295,11 @@ class GuideTable(ACACatalogTable):
         self.log(f'Checking for guide star overlap in stage-selected stars')
         nok = np.zeros(len(stage_cands)).astype(bool)
         for idx, star in enumerate(stage_cands):
+
+            # If the star was manually-selected, don't bother checking to possibly exclude it.
+            if star['id'] in self.include_ids:
+                continue
+
             for jdx, other_star in enumerate(stage_cands):
 
                 # The stage_cands are supplied in the order of preference (currently by mag)
@@ -309,6 +314,7 @@ class GuideTable(ACACatalogTable):
                     self.reject(
                         {'id': star['id'],
                          'type': 'overlap',
+                         'stage': 0,
                          'text': f'Cand {star["id"]} has track overlap with {other_star["id"]}'})
                     nok[idx] = True
         return stage_cands[~nok]

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -292,7 +292,7 @@ class GuideTable(ACACatalogTable):
         Review the stars selected at any stage and exclude stars that overlap in
         tracking space with another. Overlap is defined as being within 12 pixels.
         """
-        self.log(f'Checking for guide star overlap in stage-selected stars')
+        self.log('Checking for guide star overlap in stage-selected stars')
         nok = np.zeros(len(stage_cands)).astype(bool)
         for idx, star in enumerate(stage_cands):
 

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -326,22 +326,71 @@ def test_check_spoiler_cases():
                         [1, 1, 1, 1, 0, 0, 0]]  # dmag = 7
     assert spoiled == expected_spoiled
 
-    # Add a brighter "spoiler" that is a good guide star and confirm the test for
-    # overlapping selected stars works until just past 60 arcsec (12 pixels).
+
+def test_overlap_spoiler():
+    """
+    Add a brighter "spoiler" that is a good guide star and confirm the test for
+    overlapping selected stars works until just past (12 pixels).
+    """
+
+    # Use a blank dark map to skip imposter checks
+    dark = ACAImage(np.zeros((1024, 1024)), row0=-512, col0=-512)
+
     spoiled = []
+    drcs = np.arange(6, 17, 2)
     for drc in drcs:
         r = 10
         c = 10
         stars = StarsTable.empty()
-        stars.add_fake_star(row=r, col=c, mag=mag0, id=1, ASPQ1=0)
+        stars.add_fake_star(row=r, col=c, mag=9, id=1, ASPQ1=0)
         # Add a brighter spoiling star
-        stars.add_fake_star(row=r + drc, col=c + drc, mag=mag0 - 0.5, id=2, ASPQ1=0)
+        stars.add_fake_star(row=r, col=c + drc, mag=7, id=2, ASPQ1=0)
         selected = get_guide_catalog(**STD_INFO, stars=stars, dark=dark)
         spoiled.append(1 if (1 not in selected['id']) else 0)
-    spoiled = np.array(spoiled).reshape(-1, len(drcs)).tolist()
-    #                    0  2  4  6  8 10 12 pixels
-    expected_spoiled = [[1, 1, 1, 1, 1, 1, 0]]
+    #                   6  8 10 12 14 16  pixels
+    expected_spoiled = [1, 1, 1, 1, 0, 0]
     assert spoiled == expected_spoiled
+
+
+def test_overlap_spoiler_include():
+    """
+    Add test for overlap-star handling in cases where one or both
+    stars is in includes_ids_guide.
+    """
+    stars = StarsTable.empty()
+
+    # First, set this up with a constellation and 1 manual bright star
+    stars.add_fake_constellation(n_stars=7, mag=9)
+    stars.add_fake_star(id=1, mag=8, row=50, col=-50)
+    aca1 = get_guide_catalog(**mod_std_info(n_fid=0, n_guide=8), obsid=40000,
+                             stars=stars, dark=DARK40)
+
+    # The bright star should be included
+    assert 1 in aca1['id']
+
+    # Add another bright star within 10 pixels of id 1
+    stars.add_fake_star(id=2, mag=8.5, row=60, col=-50)
+    aca2 = get_guide_catalog(**mod_std_info(n_fid=0, n_guide=8), obsid=40000,
+                             stars=stars, dark=DARK40)
+
+    # The id 2 star is a (within 12 pixels) overlap spoiler and fainter
+    # so should not be selected
+    assert 2 not in aca2['id']
+    assert 1 in aca2['id']
+
+    # Force include the fainter star (id 2) and 1 should not be selected
+    aca3 = get_guide_catalog(**mod_std_info(n_fid=0, n_guide=8), obsid=40000,
+                             stars=stars, dark=DARK40,
+                             include_ids_guide=[2])
+    assert 2 in aca3['id']
+    assert 1 not in aca3['id']
+
+    # Force include them both and they should still be selected.
+    aca4 = get_guide_catalog(**mod_std_info(n_fid=0, n_guide=8), obsid=40000,
+                             stars=stars, dark=DARK40,
+                             include_ids_guide=[1, 2])
+    assert 2 in aca4['id']
+    assert 1 in aca4['id']
 
 
 pix_cases = [{'dither': (8, 8), 'offset_row': 4, 'offset_col': 4, 'spoils': True},

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -296,7 +296,7 @@ def test_check_spoiler_cases():
             stars.add_fake_star(row=r, col=c, mag=mag0, id=1, ASPQ1=1)
             # Add a "spoiling" star and move it from center past edge through
             # the drcs
-            stars.add_fake_star(row=r + drc, col=c, mag=mag0 + dmag, id=2, ASPQ1=0)
+            stars.add_fake_star(row=r + drc, col=c, mag=mag0 + dmag, id=2, ASPQ1=30)
             selected = get_guide_catalog(**STD_INFO, stars=stars, dark=dark)
             # Is the id=1 star spoiled / not selected?
             spoiled.append(1 if (1 not in selected['id']) else 0)
@@ -316,7 +316,7 @@ def test_check_spoiler_cases():
             stars = StarsTable.empty()
             stars.add_fake_star(row=r, col=c, mag=mag0, id=1, ASPQ1=1)
             # Add a "spoiling" star 5 mags fainter and move it from center out through a corner
-            stars.add_fake_star(row=r + drc, col=c + drc, mag=mag0 + dmag, id=2, ASPQ1=0)
+            stars.add_fake_star(row=r + drc, col=c + drc, mag=mag0 + dmag, id=2, ASPQ1=30)
             selected = get_guide_catalog(**STD_INFO, stars=stars, dark=dark)
             spoiled.append(1 if (1 not in selected['id']) else 0)
     spoiled = np.array(spoiled).reshape(-1, len(drcs)).tolist()
@@ -324,7 +324,23 @@ def test_check_spoiler_cases():
     expected_spoiled = [[1, 1, 1, 1, 0, 0, 0],  # dmag = 3
                         [1, 1, 1, 1, 0, 0, 0],  # dmag = 5
                         [1, 1, 1, 1, 0, 0, 0]]  # dmag = 7
+    assert spoiled == expected_spoiled
 
+    # Add a brighter "spoiler" that is a good guide star and confirm the test for
+    # overlapping selected stars works until just past 60 arcsec (12 pixels).
+    spoiled = []
+    for drc in drcs:
+        r = 10
+        c = 10
+        stars = StarsTable.empty()
+        stars.add_fake_star(row=r, col=c, mag=mag0, id=1, ASPQ1=0)
+        # Add a brighter spoiling star
+        stars.add_fake_star(row=r + drc, col=c + drc, mag=mag0 - 0.5, id=2, ASPQ1=0)
+        selected = get_guide_catalog(**STD_INFO, stars=stars, dark=dark)
+        spoiled.append(1 if (1 not in selected['id']) else 0)
+    spoiled = np.array(spoiled).reshape(-1, len(drcs)).tolist()
+    #                    0  2  4  6  8 10 12 pixels
+    expected_spoiled = [[1, 1, 1, 1, 1, 1, 0]]
     assert spoiled == expected_spoiled
 
 

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -296,7 +296,7 @@ def test_check_spoiler_cases():
             stars.add_fake_star(row=r, col=c, mag=mag0, id=1, ASPQ1=1)
             # Add a "spoiling" star and move it from center past edge through
             # the drcs
-            stars.add_fake_star(row=r + drc, col=c, mag=mag0 + dmag, id=2, ASPQ1=30)
+            stars.add_fake_star(row=r + drc, col=c, mag=mag0 + dmag, id=2, ASPQ1=0, CLASS=1)
             selected = get_guide_catalog(**STD_INFO, stars=stars, dark=dark)
             # Is the id=1 star spoiled / not selected?
             spoiled.append(1 if (1 not in selected['id']) else 0)
@@ -316,7 +316,7 @@ def test_check_spoiler_cases():
             stars = StarsTable.empty()
             stars.add_fake_star(row=r, col=c, mag=mag0, id=1, ASPQ1=1)
             # Add a "spoiling" star 5 mags fainter and move it from center out through a corner
-            stars.add_fake_star(row=r + drc, col=c + drc, mag=mag0 + dmag, id=2, ASPQ1=30)
+            stars.add_fake_star(row=r + drc, col=c + drc, mag=mag0 + dmag, id=2, ASPQ1=0, CLASS=1)
             selected = get_guide_catalog(**STD_INFO, stars=stars, dark=dark)
             spoiled.append(1 if (1 not in selected['id']) else 0)
     spoiled = np.array(spoiled).reshape(-1, len(drcs)).tolist()

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -295,7 +295,8 @@ def test_check_spoiler_cases():
             stars = StarsTable.empty()
             stars.add_fake_star(row=r, col=c, mag=mag0, id=1, ASPQ1=1)
             # Add a "spoiling" star and move it from center past edge through
-            # the drcs
+            # the drcs.  The spoiling star is set with CLASS=1 so it is also not a
+            # selectable guide star.
             stars.add_fake_star(row=r + drc, col=c, mag=mag0 + dmag, id=2, ASPQ1=0, CLASS=1)
             selected = get_guide_catalog(**STD_INFO, stars=stars, dark=dark)
             # Is the id=1 star spoiled / not selected?
@@ -316,6 +317,7 @@ def test_check_spoiler_cases():
             stars = StarsTable.empty()
             stars.add_fake_star(row=r, col=c, mag=mag0, id=1, ASPQ1=1)
             # Add a "spoiling" star 5 mags fainter and move it from center out through a corner
+            # The spoiling star is set with CLASS=1 so it is also not a selectable guide star.
             stars.add_fake_star(row=r + drc, col=c + drc, mag=mag0 + dmag, id=2, ASPQ1=0, CLASS=1)
             selected = get_guide_catalog(**STD_INFO, stars=stars, dark=dark)
             spoiled.append(1 if (1 not in selected['id']) else 0)


### PR DESCRIPTION
## Description

Exclude a guide star if it overlaps in pixel space with brighter/better guide star.

This PR adds a guide star selection check that guide stars are not within 12 pixels.  The PEA will drop a readout window if it actually overlaps another during the current cycle; this check should preclude star selection that would allow that.  If one or both of the close guide stars in a pair are included with include_ids(_guide) they will still be included.

This was noticed in obsids 45890 and 45884 in NOV2921A.

## Testing

- [x] Passes unit tests on linux
- [x] Functional testing - doesn't select the overlap stars in NOV2921A
