### PR TITLE
Prevent matplotlib warning

### DIFF
--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import matplotlib
 matplotlib.use('agg')  # noqa
 from matplotlib import patches
+from matplotlib.ticker import FixedLocator
 import matplotlib.pyplot as plt
 import numpy as np
 from jinja2 import Template
@@ -473,10 +474,14 @@ def plot_imposters(acq, dark, dither, vmin=100, vmax=2000,
 
     # Hack to fix up ticks to have proper row/col coords.  There must be a
     # correct way to do this.
-    xticks = [str(int(label) + img.row0) for label in ax.get_xticks().tolist()]
+    xticks_loc = ax.get_xticks().tolist()
+    xticks = [str(int(label) + img.row0) for label in xticks_loc]
+    ax.xaxis.set_major_locator(FixedLocator(xticks_loc))
     ax.set_xticklabels(xticks)
     ax.set_xlabel('Row')
-    yticks = [str(int(label) + img.col0) for label in ax.get_yticks().tolist()]
+    yticks_loc = ax.get_yticks().tolist()
+    yticks = [str(int(label) + img.col0) for label in yticks_loc]
+    x.yaxis.set_major_locator(FixedLocator(yticks_loc))
     ax.set_yticklabels(yticks)
     ax.set_ylabel('Column')
     ax.set_title('Red boxes show search box size + dither')

--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -481,7 +481,7 @@ def plot_imposters(acq, dark, dither, vmin=100, vmax=2000,
     ax.set_xlabel('Row')
     yticks_loc = ax.get_yticks().tolist()
     yticks = [str(int(label) + img.col0) for label in yticks_loc]
-    x.yaxis.set_major_locator(FixedLocator(yticks_loc))
+    ax.yaxis.set_major_locator(FixedLocator(yticks_loc))
     ax.set_yticklabels(yticks)
     ax.set_ylabel('Column')
     ax.set_title('Red boxes show search box size + dither')


### PR DESCRIPTION
## Description

This PR prevents this warning that appeared int sot/skare3/pull/755
```
FixedFormatter should only be used together with FixedLocator
```

Maybe there is a better way?

## Testing

- [x] Passes unit tests on MacOS (no warnings emitted)
- [x] Functional testing

### Functional testing

TA ran star selection for obsid 8008 using this PR and visually inspected the acq report and noticed no problems with the imposter plots (and all plots in general). Also did a side-by-side comparison with the same output from current master and saw no diffs.