### PR TITLE
Allow bonus faint guide stars for dyn bgd enabled

### DIFF
--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -92,6 +92,9 @@ def get_aca_catalog(obsid=0, **kwargs):
     :param focus_offset: SIM focus offset [steps] (default=0)
     :param target_offset: (y, z) target offset including dynamical offset
                           (2-element sequence (y, z), deg)
+    :param dyn_bgd_n_faint: number of faint stars to apply the dynamic background
+        temperature bonus ``dyn_bgd_dt_ccd`` (default=0)
+    :param dyn_bgd_dt_ccd: dynamic background T_ccd temperature bonus (default=-4.0, degC)
     :param stars: table of AGASC stars (will be fetched from agasc if None)
     :param include_ids_acq: list of AGASC IDs of stars to include in acq catalog
     :param include_halfws_acq: list of acq halfwidths corresponding to ``include_ids``.

--- a/proseco/characteristics_guide.py
+++ b/proseco/characteristics_guide.py
@@ -109,7 +109,8 @@ stages = [{"Stage": 1,
           {"Stage": 6,
            "SigErrMultiplier": 0,
            "ASPQ1Lim": 20,
-           "MagLimit": [5.0, 10.3],
+           # Final stage mag faint limit set by acceptance into candidate list
+           "MagLimit": [5.0, 20.0],
            "DoBminusVcheck": 0,
            "Spoiler": {
                "BgPixThresh": 25,

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -576,6 +576,8 @@ class ACACatalogTable(BaseCatalogTable):
     sim_offset = MetaAttribute()
     focus_offset = MetaAttribute()
     target_offset = MetaAttribute(default=(0.0, 0.0))
+    dyn_bgd_n_faint = MetaAttribute(default=0)
+    dyn_bgd_dt_ccd = MetaAttribute(default=-4.0)
     stars = MetaAttribute(pickle=False)
     include_ids_acq = IntListMetaAttribute(default=[])
     include_halfws_acq = IntListMetaAttribute(default=[])

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -888,28 +888,17 @@ def test_img_size_guide():
 
 
 def test_dyn_bgd_star_bonus():
-    """Test the star bonus for dynamic background functionality.
-    """
-    kwargs = {
-        'obsid': 23700.0,
-        'att': [-0.13602497, -0.86019897, -0.44064759, 0.21768013],
-        'date': '2022:054:19:46:41.730',
-        'detector': 'ACIS-S',
-        'dither_acq': [8, 8],
-        'dither_guide': [8, 8],
-        'man_angle': 59.59,
-        'n_acq': 8,
-        'n_fid': 3,
-        'n_guide': 5,
-        'sim_offset': 0.0,
-        'focus_offset': 0.0,
-        't_ccd_acq': -12.18,
-        't_ccd_guide': -12.18,
-        't_ccd_penalty_limit': -6.8}
+    stars = StarsTable.empty()
 
-    aca_leg = get_aca_catalog(**kwargs, dyn_bgd_n_faint=0)
-    aca_dyn = get_aca_catalog(**kwargs, dyn_bgd_n_faint=2, dyn_bgd_dt_ccd=-4.0)
-    acar_leg = aca_leg.get_review_table()
-    acar_dyn = aca_dyn.get_review_table()
-    print(np.isclose(acar_leg.guide_count, 4.46, rtol=0, atol=0.1))
-    print(np.isclose(acar_dyn.guide_count, 4.92, rtol=0, atol=0.1))
+    stars.add_fake_constellation(mag=[9.5] * 3,
+                                 size=2000, n_stars=3)
+    stars.add_fake_constellation(mag=[10.3, 10.4, 10.5, 10.6, 10.7, 12.0],
+                                 size=1500, n_stars=6)
+
+    aca_leg = get_aca_catalog(**STD_INFO, dark=DARK40, stars=stars, dyn_bgd_n_faint=0)
+    aca_dyn = get_aca_catalog(**STD_INFO, dark=DARK40, stars=stars, dyn_bgd_n_faint=2,
+                              dyn_bgd_dt_ccd=-4.0)
+    assert len(aca_leg.guides) == 3
+    assert len(aca_dyn.guides) == 5
+    assert np.allclose(aca_leg.guides['mag'], [9.5, 9.5, 9.5])
+    assert np.allclose(aca_dyn.guides['mag'], [9.5, 9.5, 9.5, 10.3, 10.4])

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -885,3 +885,31 @@ def test_img_size_guide():
 
     with pytest.raises(ValueError, match='img_size must be 4, 6, 8, or None'):
         get_aca_catalog(**mod_std_info(stars=stars, dark=dark, img_size_guide=3))
+
+
+def test_dyn_bgd_star_bonus():
+    """Test the star bonus for dynamic background functionality.
+    """
+    kwargs = {
+        'obsid': 23700.0,
+        'att': [-0.13602497, -0.86019897, -0.44064759, 0.21768013],
+        'date': '2022:054:19:46:41.730',
+        'detector': 'ACIS-S',
+        'dither_acq': [8, 8],
+        'dither_guide': [8, 8],
+        'man_angle': 59.59,
+        'n_acq': 8,
+        'n_fid': 3,
+        'n_guide': 5,
+        'sim_offset': 0.0,
+        'focus_offset': 0.0,
+        't_ccd_acq': -12.18,
+        't_ccd_guide': -12.18,
+        't_ccd_penalty_limit': -6.8}
+
+    aca_leg = get_aca_catalog(**kwargs, dyn_bgd_n_faint=0)
+    aca_dyn = get_aca_catalog(**kwargs, dyn_bgd_n_faint=2, dyn_bgd_dt_ccd=-4.0)
+    acar_leg = aca_leg.get_review_table()
+    acar_dyn = aca_dyn.get_review_table()
+    print(np.isclose(acar_leg.guide_count, 4.46, rtol=0, atol=0.1))
+    print(np.isclose(acar_dyn.guide_count, 4.92, rtol=0, atol=0.1))


### PR DESCRIPTION
## Description

Per discussion at SS&AWG on 2022-Apr-27 (see the presentation there for full details), this adds two new parameters to the base `ACACatalogTable` and the `get_aca_catalog` function to allow specifying the parameters of the bonus stars.

Requires:
- https://github.com/sot/sparkles/pull/172
- https://github.com/sot/chandra_aca/pull/124

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds `dyn_bgd_n_faint` and `dyn_bgd_dt_ccd` arguments to `get_aca_catalog`. The default settings (in particular `dyn_bgd_n_faint = 0`) have behavior that is identical to current flight star selection.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests using above-mentioned branches
- [x] Mac

Independent check of unit tests by Javier
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

- https://nbviewer.org/urls/cxc.cfa.harvard.edu/mta/ASPECT/proseco/test-dyn-bgd-bonus-stars.ipynb
- https://nbviewer.org/urls/cxc.cfa.harvard.edu/mta/ASPECT/proseco/test-dyn-bgd-bonus-stars-obs23700.ipynb
