### PR TITLE
Add man_angle_next kwarg / attribute

### DIFF
--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -76,6 +76,8 @@ def get_aca_catalog(obsid=0, **kwargs):
     :param n_guide: desired number of guide stars + monitor windows (req'd unless obsid spec'd)
     :param monitors: N x 5 float array specifying monitor windows
     :param man_angle: maneuver angle (deg)
+    :param man_angle_next: maneuver angle to next attitude after this observation
+                           (deg, default=180)
     :param t_ccd_acq: ACA CCD temperature for acquisition (degC)
     :param t_ccd_guide: ACA CCD temperature for guide (degC)
     :param t_ccd_penalty_limit: ACA CCD penalty limit for planning (degC). If not

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -574,7 +574,7 @@ class ACATable(ACACatalogTable):
                  f"acq_idxs={best_acq_idxs} halfws={best_acq_halfws} fid_ids={acqs.fid_set}")
 
         if best_P2 < stage_min_P2:
-            self.log(f'No acq-fid combination was found that met stage requirements',
+            self.log('No acq-fid combination was found that met stage requirements',
                      warning=True)
 
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -566,6 +566,7 @@ class ACACatalogTable(BaseCatalogTable):
     n_fid = MetaAttribute()
     monitors = MonitorsMetaAttribute()
     man_angle = MetaAttribute()
+    man_angle_next = MetaAttribute(default=180.0)
     t_ccd_acq = MetaAttribute()
     t_ccd_guide = MetaAttribute()
     date = MetaAttribute()

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -902,3 +902,15 @@ def test_dyn_bgd_star_bonus():
     assert len(aca_dyn.guides) == 5
     assert np.allclose(aca_leg.guides['mag'], [9.5, 9.5, 9.5])
     assert np.allclose(aca_dyn.guides['mag'], [9.5, 9.5, 9.5, 10.3, 10.4])
+
+
+def test_man_angle_away():
+    aca1 = get_aca_catalog(**STD_INFO)
+    aca2 = get_aca_catalog(**STD_INFO, man_angle_next=5)
+    assert np.all(aca1['id'] == aca2['id'])
+    assert np.all(aca1.acqs['halfw'] == aca2.acqs['halfw'])
+
+    # Confirm that the man_angle_next attribute has the default value
+    # for aca1 (180) and the specified kw value for aca2
+    assert aca1.man_angle_next == 180
+    assert aca2.man_angle_next == 5


### PR DESCRIPTION
## Description

Add man_angle_next kwarg/attribute.

## Interface impacts
Adds man_angle_next kwarg/attribute.

## Testing

### Unit tests
- [x] Linux


Independent check of unit tests by @taldcroft
- [x] Mac

### Functional tests
New test added that confirms kwarg can be supplied, that it populates at attribute at at least the top level of the aca catalog table, and doesn't change the effective catalog.


