### PR TITLE
Change default OR guide and acq image size to 8x8 pixels

### DIFF
--- a/proseco/__init__.py
+++ b/proseco/__init__.py
@@ -75,7 +75,8 @@ def get_aca_catalog(*args, **kwargs):
     :param include_ids_guide: list of AGASC IDs of stars to include in guide catalog
     :param exclude_ids_guide: list of AGASC IDs of stars to exclude from guide catalog
     :param img_size_guide: readout window size for guide stars (6, 8, or ``None``).
-                           For default value ``None`` use 8 for no fids, 6 for fids.
+        Default value: 8 for ER's; PROSECO_OR_IMAGE_SIZE environment value if
+        if set, otherwise 8.
     :param optimize: optimize star catalog after initial selection (default=True)
     :param verbose: provide extra logging info (mostly calc_p_safe) (default=False)
     :param print_log: print the run log to stdout (default=False)

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -717,7 +717,7 @@ def merge_cats(fids=None, guides=None, acqs=None, mons=None):
 
     if len(acqs) > 0:
         # TODO: move these into acq.py where possible
-        img_size = get_img_size(len(fids))
+        img_size = guides.img_size or get_img_size(len(fids))
         acqs["type"] = "ACQ"
 
         # Set maxmag for acqs. Start w/ legacy version corresponding to behavior

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -1919,8 +1919,15 @@ def get_dim_res(halfws):
 def get_img_size(n_fids):
     """Get guide image readout size from ``n_fids``.
 
-    This is the core definition for the default rule that OR's (with fids) get
-    6x6 and ER's (no fids) get 8x8. This might change in the future.
+    This is the core definition for the default rule specifying the guide star
+    image size.
+
+    ER's (observations with no fids) always get 8x8.
+
+    OR's (observations with fids) default to 8x8. This can be globally
+    overridden by setting the ``PROSECO_OR_IMAGE_SIZE`` environment
+    variable to "4", "6" or "8". As a reminder the ``img_size_guide`` parameter
+    of ``get_aca_catalog`` can also be set.
 
     Parameters
     ----------
@@ -1932,4 +1939,9 @@ def get_img_size(n_fids):
     int
         Guide star image readout size to be used in a catalog (6 or 8)
     """
-    return 6 if n_fids > 0 else 8
+    default_or_img_size = os.environ.get("PROSECO_OR_IMAGE_SIZE", "8")
+    if default_or_img_size not in ("4", "6", "8"):
+        raise ValueError(
+            f"PROSECO_OR_IMAGE_SIZE must be 6 or 8, not {default_or_img_size}"
+        )
+    return int(default_or_img_size) if n_fids > 0 else 8

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -202,8 +202,9 @@ class GuideTable(ACACatalogTable):
     def get_img_size(self, n_fids=None):
         """Get guide image readout size from ``img_size`` and ``n_fids``.
 
-        If img_size is None (typical case) then this uses the default rule
-        that OR's get 6x6 and ER's (no fids) get 8x8.
+        If img_size is None (typical case) then this uses the default rules
+        defined in ``core.get_img_size()``, namely 8x8 for all guide stars
+        unless overridden by the PROSECO_OR_IMAGE_SIZE environment variable.
 
         This requires that the ``fids`` attribute has been set, normally by
         providing the table as an arg to ``get_guide_catalog()``.

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -196,7 +196,7 @@ def test_get_kwargs_from_starcheck_text():
     assert mon["zang"] == 500.0
 
 
-def test_get_kwargs_from_starcheck_text2():
+def test_get_kwargs_from_starcheck_text2(monkeypatch):
     text2 = """
     OBSID: 23156  WR 140                 ACIS-S SIM Z offset:0     (0.00mm) Grating: HETG
     RA, Dec, Roll (deg):   305.083054    43.865507   310.023234
@@ -232,7 +232,7 @@ def test_get_kwargs_from_starcheck_text2():
     Predicted Max CCD temperature: -11.2 C  N100 Warm Pix Frac 0.291
     Dynamic Mag Limits: Yellow 10.30  Red 10.56
     """
-
+    monkeypatch.setenv("PROSECO_OR_IMAGE_SIZE", "6")
     kwargs = get_kwargs_from_starcheck_text(text2, force_catalog=True, include_cat=True)
     cat_exp = kwargs.pop("cat")
     exp = {

--- a/proseco/tests/test_mon_full_cat.py
+++ b/proseco/tests/test_mon_full_cat.py
@@ -38,7 +38,7 @@ def test_monitor_input_processing_ra_dec(stars):
     aca = get_aca_catalog(
         **mod_std_info(att=stars.att, n_fid=0, n_guide=5),
         stars=stars,
-        monitors=monitors
+        monitors=monitors,
     )
     monitors = aca.mons.monitors
     assert len(monitors) == 1
@@ -72,7 +72,7 @@ def test_monitor_mon_fixed_auto():
     aca = get_aca_catalog(
         monitors=monitors,
         **mod_std_info(n_guide=6, n_fid=2),
-        include_ids_guide=[611192064]
+        include_ids_guide=[611192064],
     )
 
     exp = [
@@ -80,17 +80,17 @@ def test_monitor_mon_fixed_auto():
         "---- --- --------- ---- --- -------- -------- --- --- -----",
         "   0   1         4  FID 8x8  2140.23   166.63   1   1    25",
         "   1   2         5  FID 8x8 -1826.28   160.17   1   1    25",
-        "   2   3 611190016  BOT 6x6   175.44 -1297.92  28   1   160",
-        "   3   4    139192  BOT 6x6   587.27   802.49  28   1   160",
+        "   2   3 611190016  BOT 8x8   175.44 -1297.92  28   1   160",
+        "   3   4    139192  BOT 8x8   587.27   802.49  28   1   160",
         "   7   5 611192384  BOT 8x8  1053.38  -275.16  28   1   160",
-        "   4   6 611192064  GUI 6x6  2003.89 -1746.97   1   1    25",
+        "   4   6 611192064  GUI 8x8  2003.89 -1746.97   1   1    25",
         "   5   7      1001  MON 8x8  -219.72  -273.87   2   0    20",
         "   6   8      1000  MON 8x8 -1700.00  1900.00   6   0    20",
-        "   0   9 688523960  ACQ 6x6  -202.71 -1008.91  28   1   160",
-        "   1  10 688521312  ACQ 6x6  -739.68 -1799.85  28   1   160",
-        "   4  11 611189488  ACQ 6x6  1536.83  -786.12  28   1   160",
-        "   5  12 688522008  ACQ 6x6  -743.78 -2100.94  28   1   160",
-        "   6  13    134680  ACQ 6x6  1314.00  1085.73  28   1   160",
+        "   0   9 688523960  ACQ 8x8  -202.71 -1008.91  28   1   160",
+        "   1  10 688521312  ACQ 8x8  -739.68 -1799.85  28   1   160",
+        "   4  11 611189488  ACQ 8x8  1536.83  -786.12  28   1   160",
+        "   5  12 688522008  ACQ 8x8  -743.78 -2100.94  28   1   160",
+        "   6  13    134680  ACQ 8x8  1314.00  1085.73  28   1   160",
     ]
 
     assert aca[TEST_COLS].pformat_all() == exp
@@ -135,27 +135,27 @@ def test_full_catalog():
         **mod_std_info(att=stars.att, n_fid=1, n_guide=7),
         stars=stars,
         monitors=monitors,
-        exclude_ids_acq=[100000, 100001, 51, 100003]
+        exclude_ids_acq=[100000, 100001, 51, 100003],
     )
 
     exp = [
         "slot idx   id   type  sz   yang     zang   dim res halfw  mag ",
         "---- --- ------ ---- --- -------- -------- --- --- ----- -----",
         "   0   1      1  FID 8x8   922.59 -1737.89   1   1    25  7.00",
-        "   1   2 100007  BOT 6x6  -750.00  -750.00  28   1   160  7.00",
-        "   2   3 100006  BOT 6x6  -750.00   750.00  28   1   160  7.50",
-        "   3   4 100005  BOT 6x6   750.00  -750.00  28   1   160  8.00",
+        "   1   2 100007  BOT 8x8  -750.00  -750.00  28   1   160  7.00",
+        "   2   3 100006  BOT 8x8  -750.00   750.00  28   1   160  7.50",
+        "   3   4 100005  BOT 8x8   750.00  -750.00  28   1   160  8.00",
         "   6   5     50  BOT 8x8   100.00   200.00  28   1   160  6.50",
-        "   4   6 100003  GUI 6x6     0.00 -1500.00   1   1    25  9.00",
+        "   4   6 100003  GUI 8x8     0.00 -1500.00   1   1    25  9.00",
         # Mag from star cat not monitors and sz=8x8. Position is also from
         # star cat since monitors yag/zag = -1001, -2001.
         "   7   7     51  GUI 8x8 -1000.00 -2000.00   1   1    25  6.25",
         # Mag from monitors and dim=7 (=> tracking brightest star in slot 7,
         # which happens to be a GUI from MON).
         "   5   8   1000  MON 8x8     0.00     0.00   7   0    20  6.12",
-        "   0   9 100004  ACQ 6x6   750.00   750.00  28   1   160  8.50",
-        "   4  10 100002  ACQ 6x6 -1500.00     0.00  28   1   160  9.50",
-        "   5  11 100008  ACQ 6x6   400.00   400.00   8   1    60 10.50",
+        "   0   9 100004  ACQ 8x8   750.00   750.00  28   1   160  8.50",
+        "   4  10 100002  ACQ 8x8 -1500.00     0.00  28   1   160  9.50",
+        "   5  11 100008  ACQ 8x8   400.00   400.00   8   1    60 10.50",
     ]
 
     assert aca[TEST_COLS + ["mag"]].pformat_all() == exp
@@ -179,7 +179,7 @@ def test_mon_takes_guide():
     aca = get_aca_catalog(
         **mod_std_info(att=stars.att, n_fid=0, n_guide=5, n_acq=5),
         stars=stars,
-        monitors=monitors
+        monitors=monitors,
     )
 
     # This has 4 + 1 stars in the "guide" catalog, where the MON has taken one slot.


### PR DESCRIPTION
## Description

Per agreement of SS&AWG this PR updates proseco to default to using 8x8 pixel images for all guide stars. In particular this changes the default for OR catalogs from 6x6 pixels to 8x8 pixels.

This is targeted for inclusion in MATLAB 2022_060.

The new default can be globally overridden with an environment variable `PROSECO_OR_IMAGE_SIZE` which can be set to one of `4`, `6`, or `8`.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Closes #378

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Changes the default guide star image size for OR's (observations with fids) from 6x6 to 8x8.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [X] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
