### PR TITLE
Get rid of pytest.warns deprecation warning

### DIFF
--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -939,7 +939,7 @@ def test_dark_date_warning():
 
     # Fudge date forward, after the 2018:002 dark cal
     acap.date = "2018:010"
-    with pytest.warns(None) as warns:
+    with pytest.warns(UserWarning) as warns:
         acap.dark  # Accessing the `dark` property triggers code to read it (and warn)
 
     assert len(warns) == 1


### PR DESCRIPTION
## Description

In ska3-prime (python 3.10) we get the following warning in unit tests:
```
PytestRemovedIn8Warning: Passing None has been deprecated.
```

This PR gets rid of that warning by explicitly setting the type of warning expected.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests

- [x] Mac

Independent check of unit tests by Jean
- [X] Mac

### Functional tests
I checked that the warning went away with this PR using ska3-flight 2023.1rc4

(I'm still getting a numpy DeprecationWarning on ctypeslib, but at least this PR cleans up the one from our own code -Jean).
