### PR TITLE
Pin chandra_models version to 3.48 for all tests

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -1398,7 +1398,6 @@ def calc_p_on_ccd(row, col, box_size):
         (row, max_ccd_row, box_size.row),
         (col, max_ccd_col, box_size.col),
     ):
-
         # Pixel boundaries are symmetric so just take abs(row/col)
         rc1 = abs(rc) + half_width
 

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -348,13 +348,11 @@ class GuideTable(ACACatalogTable):
         self.log("Checking for guide star overlap in stage-selected stars")
         nok = np.zeros(len(stage_cands)).astype(bool)
         for idx, star in enumerate(stage_cands):
-
             # If the star was manually-selected, don't bother checking to possibly exclude it.
             if star["id"] in self.include_ids:
                 continue
 
             for jdx, other_star in enumerate(stage_cands):
-
                 # The stage_cands are supplied in the order of preference (currently by mag)
                 # Check and exclude a guide star only if it would spoil a lower index (better) star.
                 if idx <= jdx:

--- a/proseco/report_acq.py
+++ b/proseco/report_acq.py
@@ -161,7 +161,6 @@ def make_cand_acqs_report(acqs, cand_acqs, events, context, obsdir):
     # Now plot figure
     filename = obsdir / "candidate_stars.png"
     if not filename.exists():
-
         # Pull a fast-one and mark the final selected ACQ stars as BOT so they
         # get a circle in the plot.  This might be confusing and need fixing
         # later, but for now it is an easy way to show the winning candidates.

--- a/proseco/report_guide.py
+++ b/proseco/report_guide.py
@@ -130,7 +130,6 @@ def make_report(obsid, rootdir="."):
 
 
 def make_cand_report(guides, cand_guides, context, obsdir):
-
     n_stages = np.max(cand_guides["stage"])
     context["cand_guides"] = []
     for ii, guide in enumerate(cand_guides):

--- a/proseco/tests/conftest.py
+++ b/proseco/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def use_fixed_chandra_models(monkeypatch):
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -674,7 +674,7 @@ def test_get_ax_range():
     """
     ns = [0, 0.71, 495.3, -200.2]
     extents = [4.0, 5.6, 4.8, 9.0]
-    for (n, extent) in itertools.product(ns, extents):
+    for n, extent in itertools.product(ns, extents):
         minus, plus = get_ax_range(n, extent)
         # Confirm range divisable by 2
         assert (plus - minus) % 2 == 0


### PR DESCRIPTION
## Description

Pin chandra_models version to 3.48 for all tests with a pytest fixture that sets the environment variable.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
I configured with CHANDRA_MODELS_REPO_DIR to /Users/jean/git/chandra_models, set that chandra_models to be at pitch-roll-constraint-2023_020, set CHANDRA_MODELS_DEFAULT_VERSION to pitch-roll-constraint-2023_020, and added a throwaway tag in /Users/jean/git/chandra_models so it would still stop complaining that tip wasn't at tag 3.49.  With that setup, I was reliably able to get the tests that (apparently) use the acquisition model to fail without this PR.  I did not try to isolate acquisition model and pitch/roll changes.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac


Independent check of unit tests by @taldcroft (with the same setup noted above except without the "throwaway tag")
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Unit tests are functional tests for this change.
