### PR TITLE
Add acq prob model info dict as a new pickled attribute

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,13 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.3.0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.10
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
-      - id: isort
-        name: isort (python)
+    - id: isort
+      name: isort (python)
+      language_version: python3.10

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -11,7 +11,11 @@ import warnings
 from pathlib import Path
 
 import numpy as np
-from chandra_aca.star_probs import acq_success_prob, prob_n_acq
+from chandra_aca.star_probs import (
+    acq_success_prob,
+    get_default_acq_prob_model_info,
+    prob_n_acq,
+)
 from chandra_aca.transform import mag_to_count_rate, pixels_to_yagzag, snr_mag_for_t_ccd
 from scipy import ndimage, stats
 from scipy.interpolate import interp1d
@@ -210,6 +214,9 @@ def get_acq_catalog(obsid=0, **kwargs):
             warning=True,
         )
 
+    # Get the acq prob model info and add to the table.
+    acqs.acq_prob_model_info = get_default_acq_prob_model_info(verbose=False)
+
     return acqs
 
 
@@ -252,6 +259,7 @@ class AcqTable(ACACatalogTable):
     p_safe = MetaAttribute(is_kwarg=False)
     _fid_set = MetaAttribute(is_kwarg=False, default=())
     imposters_mag_limit = MetaAttribute(is_kwarg=False, default=20.0)
+    acq_prob_model_info = MetaAttribute(is_kwarg=False)
 
     @classmethod
     def empty(cls):


### PR DESCRIPTION
## Description

This finally takes advantage of the info infrastructure in https://github.com/sot/ska_helpers/pull/33 to provide clear provenance of the acquisition probability model that was used to generate an acq catalog.

### Requires
- https://github.com/sot/chandra_aca/pull/151
- https://github.com/sot/ska_helpers/pull/33

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds a new `acq_prob_model_info` meta-attribute to `AcqTable`.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
Tested in a dev ska with the required `ska_helpers` and `chandra_aca` in the path.
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
