### PR TITLE
Make ACA penalty limit optional

### DIFF
--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -270,7 +270,7 @@ def get_effective_t_ccd(t_ccd, t_ccd_penalty_limit=None):
         if t_ccd_penalty_limit is None
         else t_ccd_penalty_limit
     )
-    if t_ccd > t_limit:
+    if t_limit is not None and t_ccd > t_limit:
         return t_ccd + 1 + (t_ccd - t_limit)
     else:
         return t_ccd

--- a/proseco/characteristics.py
+++ b/proseco/characteristics.py
@@ -77,14 +77,12 @@ def _load_bad_star_set():
 
 bad_star_set = LazyDict(_load_bad_star_set)
 
-# Version of chandra_models to use for the ACA xija model from which the
-# planning and penalty limits are extracted. Default of None means use the
-# current flight-approved version. For testing or other rare circumstances this
-# can be overridden prior to calling get_aca_catalog(). This module variable
-# gets set to the actual chandra_models version when the ACA attributes are
-# first accessed.
+# READ-ONLY variable which gives the version of chandra_models being use for the ACA
+# xija model from which the planning and penalty limits are extracted. This module
+# variable is set on demand to the chandra_models repo version. To select a specific
+# version set the CHANDRA_MODELS_DEFAULT_VERSION environment variable.
 #
-# chandra_models_version = None
+# chandra_models_version
 
 # The next two characteristics are lazily defined to ensure import succeeds.
 

--- a/proseco/characteristics.py
+++ b/proseco/characteristics.py
@@ -1,4 +1,7 @@
+import json
+
 import agasc
+from ska_helpers import chandra_models
 from ska_helpers.utils import LazyDict
 
 CCD = {
@@ -80,7 +83,8 @@ bad_star_set = LazyDict(_load_bad_star_set)
 # can be overridden prior to calling get_aca_catalog(). This module variable
 # gets set to the actual chandra_models version when the ACA attributes are
 # first accessed.
-chandra_models_version = None
+#
+# chandra_models_version = None
 
 # The next two characteristics are lazily defined to ensure import succeeds.
 
@@ -93,7 +97,11 @@ chandra_models_version = None
 
 def __getattr__(name):
     """Lazily define module attributes for the ACA planning and penalty limits"""
-    if name in ("aca_t_ccd_penalty_limit", "aca_t_ccd_planning_limit"):
+    if name in (
+        "chandra_models_version",
+        "aca_t_ccd_penalty_limit",
+        "aca_t_ccd_planning_limit",
+    ):
         _set_aca_limits()
         return globals()[name]
     else:
@@ -103,25 +111,16 @@ def __getattr__(name):
 def _set_aca_limits():
     """Set global variables for ACA thermal planning and penalty limits"""
     global chandra_models_version
-    from xija.get_model_spec import get_xija_model_spec
 
-    spec, chandra_models_version = get_xija_model_spec(
-        "aca", version=chandra_models_version
-    )
+    spec_txt, info = chandra_models.get_data("chandra_models/xija/aca/aca_spec.json")
+    spec = json.loads(spec_txt)
+
+    chandra_models_version = info["version"]
 
     names = ("aca_t_ccd_penalty_limit", "aca_t_ccd_planning_limit")
     spec_names = ("planning.penalty.high", "planning.warning.high")
     for name, spec_name in zip(names, spec_names):
-        try:
-            limit = spec["limits"]["aacccdpt"][spec_name]
-        except KeyError:
-            raise KeyError(
-                f"unable to find ['limits']['aacccdpt']['{spec_name}'] "
-                "in the ACA xija model in "
-                f"chandra_models version {chandra_models_version}."
-            )
-        else:
-            globals()[name] = limit
+        globals()[name] = spec["limits"]["aacccdpt"].get(spec_name)
 
 
 # Make sure module-level `dir()` includes the lazy attributes.


### PR DESCRIPTION
## Description

Make the ACA penalty limit from the chandra_models `aca_spec.json` file be *optional*. This also makes the ACA planning limit optional for proseco, though it is still needed in other tools.

If not provided there is no penalty limit and the effective CCD temperature is the same as the actual (predicted) temperature. In this case the `t_ccd_penalty_limit` attribute of an ACA catalog is `None`.

This PR also transitions to using `ska_helpers.chandra_models` to get the chandra_models data. This is helpful to enable testing using the `CHANDRA_MODELS_REPO_DIR` and `CHANDRA_MODELS_DEFAULT_VERSION` env vars.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
 `CHANDRA_MODELS_REPO_DIR` and `CHANDRA_MODELS_DEFAULT_VERSION` env vars now work with proseco for selection of the aca thermal model for limits.  Those vars already worked to define the acquisition model used within proseco via chandra_aca.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

#### chandra_models update
Starting from chandra_models version 3.49, I made a new branch `no-penalty-limit` and edited `chandra_models/xija/aca/aca_spec.json` to remove the penalty limit.
```
➜  chandra_models git:(no-penalty-limit) git diff 3.49                         
diff --git a/chandra_models/xija/aca/aca_spec.json b/chandra_models/xija/aca/aca_spec.json
index 87665ca..7912ffe 100644
--- a/chandra_models/xija/aca/aca_spec.json
+++ b/chandra_models/xija/aca/aca_spec.json
@@ -273,7 +273,6 @@
     },
     "limits": {
         "aacccdpt": {
-            "planning.penalty.high": -4.0,
             "planning.warning.high": -4.5,
             "unit": "degC"
         }
```

#### Simple test
```
$ export CHANDRA_MODELS_REPO_DIR=/Users/aldcroft/tmp/chandra_models
$ export CHANDRA_MODELS_DEFAULT_VERSION=no-penalty-limit    
$ ipython
In [1]: from proseco.tests.test_common import mod_std_info
In [2]: from proseco import get_aca_catalog
In [3]: aca = get_aca_catalog(**mod_std_info(t_ccd=-2.0))
In [4]: aca.t_ccd_acq
Out[4]: -2.0

In [5]: aca.t_ccd_eff_acq
Out[5]: -2.0

In [6]: print(aca.t_ccd_penalty_limit)
None

In [7]: import proseco.characteristics as ACA

In [8]: ACA.chandra_models_version
Out[8]: 'no-penalty-limit'

In [9]: ACA.aca_t_ccd_planning_limit
Out[9]: -4.5

In [10]: print(ACA.aca_t_ccd_penalty_limit)
None
```
