### PR TITLE
Allow specifying AGASC HDF5 file or latest proseco_agasc as default

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,8 +19,6 @@ Guide
 
 .. automodule:: proseco.guide
    :members:
-.. autoclass:: GuideTable
-   :members:
 
 Fid
 ---

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -109,7 +109,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -303,8 +303,12 @@ Environment Variables
 
 The following environment variables are used by proseco:
 
+- ``AGASC_DIR``: path to AGASC directory for getting AGASC star data. This
+  overrides the default value of ``$SKA/data/agasc``.
 - ``AGASC_HDF5_FILE``: path to AGASC HDF5 file for getting AGASC star data. This
-  overrides the default value of ``$SKA/data/agasc/proseco_agasc_<latest>.h5``.
+  overrides the default value of ``<default_agasc_dir>/proseco_agasc_<latest>.h5``,
+  where ``<default_agasc_dir> = $AGASC_DIR or $SKA/data/agasc``.
+  If this is a relative path then it is relative to ``<default_agasc_dir>``.
 - ``AGASC_SUPPLEMENT_ENABLED``: set to ``"False"`` to disable using the AGASC
    supplement. This is for testing and should not be used in production.
 - ``PROSECO_IGNORE_MAXAGS_CONSTRAINTS``: if set then do not update ``maxmag`` in the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -283,7 +283,7 @@ Required data files are:
 
 ::
 
-  $SKA/data/agasc/proseco_agasc_1p7.h5
+  $SKA/data/agasc/proseco_agasc_<latest>.h5
   $SKA/data/mica/archive/aca_dark/<YYYYddd>/image.fits
   $SKA/data/mica/archive/aca_dark/<YYYYddd>/properties.json
 
@@ -297,6 +297,23 @@ See `Syncing Ska data
 <https://github.com/sot/skare3/wiki/Ska3-runtime-environment-for-users#ska-data>`_
 for details on automatically syncing these files for a standalone linux or Mac
 environment.  For Matlab tools on Windows a separate mechanism will be provided.
+
+Environment Variables
+---------------------
+
+The following environment variables are used by proseco:
+
+- ``AGASC_HDF5_FILE``: path to AGASC HDF5 file for getting AGASC star data. This
+  overrides the default value of ``$SKA/data/agasc/proseco_agasc_<latest>.h5``.
+- ``AGASC_SUPPLEMENT_ENABLED``: set to ``"False"`` to disable using the AGASC
+   supplement. This is for testing and should not be used in production.
+- ``PROSECO_IGNORE_MAXAGS_CONSTRAINTS``: if set then do not update ``maxmag`` in the
+  catalog to prevent search hits clipping.
+- ``PROSECO_OR_IMAGE_SIZE``: override the default OR image size of 8x8. Can be one of
+  "4", "6", or "8".
+- ``PROSECO_PRINT_OBC_CAT``: if set then create and print a debug catalog while doing
+  catalog merging.
+- ``SKA``: root directory for Ska3 runtime environment
 
 API docs
 --------

--- a/proseco/catalog.py
+++ b/proseco/catalog.py
@@ -124,7 +124,10 @@ def _get_aca_catalog(**kwargs):
     # Get stars (typically from AGASC) and do not filter for stars near
     # the ACA FOV.  This leaves the full radial selection available for
     # later roll optimization.  Use aca.stars or aca.acqs.stars from here.
+    # Set the agasc_file MetaAttribute if it is available in the stars table meta.
     aca.set_stars(filter_near_fov=False)
+    if "agasc_file" in aca.stars.meta:
+        aca.agasc_file = aca.stars.meta["agasc_file"]
 
     aca.log("Starting get_acq_catalog")
     aca.acqs = get_acq_catalog(stars=aca.stars, **kwargs)
@@ -302,6 +305,7 @@ class ACATable(ACACatalogTable):
     optimize = MetaAttribute(default=True)
     call_args = MetaAttribute(default={})
     version = MetaAttribute()
+    agasc_file = MetaAttribute(is_kwarg=False)
 
     # For validation with get_aca_catalog(obsid), store the starcheck
     # catalog in the ACATable meta.

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -1305,6 +1305,8 @@ class StarsTable(BaseCatalogTable):
         :returns: StarsTable of stars (empty)
         """
         stars = cls.from_agasc(att, radius=-1)
+        # Remove "agasc_file" meta key since it does not apply for a synthetic table.
+        del stars.meta["agasc_file"]
         stars.att = att
 
         return stars

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -1174,9 +1174,11 @@ class StarsTable(BaseCatalogTable):
         :returns: StarsTable of stars
         """
         q_att = Quat(att)
-        agasc_file = Path(os.environ.get("AGASC_HDF5_FILE", "proseco_agasc"))
+        # The AGASC file being used is delegated to the agasc module default, which
+        # is the latest proseco_agasc file unless overridden by the  AGASC_HDF5_FILE.
+        # The AGASC_DIR env vars controls where the AGASC files are located.
         agasc_stars = agasc.get_agasc_cone(
-            q_att.ra, q_att.dec, radius=radius, date=date, agasc_file=agasc_file
+            q_att.ra, q_att.dec, radius=radius, date=date
         )
         stars = StarsTable.from_stars(att, agasc_stars, copy=False)
 

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -1158,8 +1158,13 @@ class StarsTable(BaseCatalogTable):
     @classmethod
     def from_agasc(cls, att, date=None, radius=1.2, logger=None):
         """
-        Get AGASC stars in the ACA FOV.  This uses the mini-AGASC, so only stars
-        within 3-sigma of 11.5 mag.
+        Get AGASC stars in the ACA FOV.  This uses the proseco-AGASC, so only stars
+        within 3-sigma of 11.5 mag or those nearby a potential guide/acq star are
+        included.
+
+        This uses an AGASC file path defined by the AGASC_HDF_FILE env var or the latest
+        version of proseco_agasc in the default AGASC directory. The AGASC directory can
+        be set with the AGASC_DIR env var.
 
         :param att: any Quat-compatible attitude
         :param date: DateTime compatible date for star proper motion (default=NOW)
@@ -1169,7 +1174,7 @@ class StarsTable(BaseCatalogTable):
         :returns: StarsTable of stars
         """
         q_att = Quat(att)
-        agasc_file = Path(os.environ["SKA"], "data", "agasc", "proseco_agasc_1p7.h5")
+        agasc_file = Path(os.environ.get("AGASC_HDF5_FILE", "proseco_agasc"))
         agasc_stars = agasc.get_agasc_cone(
             q_att.ra, q_att.dec, radius=radius, date=date, agasc_file=agasc_file
         )

--- a/proseco/tests/conftest.py
+++ b/proseco/tests/conftest.py
@@ -1,6 +1,25 @@
 import pytest
+from agasc import get_agasc_filename
 
 
 @pytest.fixture(autouse=True)
 def use_fixed_chandra_models(monkeypatch):
     monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
+
+
+@pytest.fixture()
+def proseco_agasc_1p7(monkeypatch):
+    agasc_file = get_agasc_filename("proseco_agasc_*", version="1p7")
+    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)
+
+
+@pytest.fixture()
+def miniagasc_1p7(monkeypatch):
+    agasc_file = get_agasc_filename("miniagasc_*", version="1p7")
+    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)
+
+
+@pytest.fixture(autouse=True)
+def proseco_agasc_rc(monkeypatch):
+    agasc_file = get_agasc_filename("proseco_agasc_*", allow_rc=True)
+    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)

--- a/proseco/tests/conftest.py
+++ b/proseco/tests/conftest.py
@@ -7,6 +7,13 @@ def use_fixed_chandra_models(monkeypatch):
     monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
 
 
+# By default test with the latest AGASC version available including release candidates
+@pytest.fixture(autouse=True)
+def proseco_agasc_rc(monkeypatch):
+    agasc_file = get_agasc_filename("proseco_agasc_*", allow_rc=True)
+    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)
+
+
 @pytest.fixture()
 def proseco_agasc_1p7(monkeypatch):
     agasc_file = get_agasc_filename("proseco_agasc_*", version="1p7")
@@ -16,10 +23,4 @@ def proseco_agasc_1p7(monkeypatch):
 @pytest.fixture()
 def miniagasc_1p7(monkeypatch):
     agasc_file = get_agasc_filename("miniagasc_*", version="1p7")
-    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)
-
-
-@pytest.fixture(autouse=True)
-def proseco_agasc_rc(monkeypatch):
-    agasc_file = get_agasc_filename("proseco_agasc_*", allow_rc=True)
     monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)

--- a/proseco/tests/test_acq.py
+++ b/proseco/tests/test_acq.py
@@ -431,7 +431,7 @@ def test_calc_p_on_ccd_asymmetric_dither():
         assert np.isclose(p_in_box, exp)
 
 
-def test_get_acq_catalog_19387():
+def test_get_acq_catalog_19387(proseco_agasc_1p7):
     """Put it all together.  Regression test for selected stars.  This obsid
     actually changes out one of the initial catalog candidates.
 
@@ -466,7 +466,7 @@ def test_get_acq_catalog_19387():
     assert repr(acqs.cand_acqs[TEST_COLS]).splitlines() == exp
 
 
-def test_get_acq_catalog_21007():
+def test_get_acq_catalog_21007(proseco_agasc_1p7):
     """Put it all together.  Regression test for selected stars.
 
     Also test that the acq prob model info dict is correctly set.
@@ -544,7 +544,7 @@ def test_get_acq_catalog_21007():
     assert info == exp
 
 
-def test_box_strategy_20603():
+def test_box_strategy_20603(proseco_agasc_1p7):
     """Test for PR #32 that doesn't allow p_acq to be reduced below 0.1.
 
     The idx=8 (mag=10.50) star was previously selected with 160 arsec box.

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -129,6 +129,7 @@ def test_get_aca_catalog_20603(proseco_agasc_1p7):
     aca.fids.plot()
 
     assert aca.dark_date == "2018:100"
+    assert Path(aca.agasc_file).name == "proseco_agasc_1p7.h5"
 
 
 @pytest.mark.skipif(not HAS_SC_ARCHIVE, reason="Test requires starcheck archive")
@@ -273,6 +274,9 @@ def test_pickle():
     stars = StarsTable.empty()
     stars.add_fake_constellation(mag=10.0, n_stars=5)
     aca = get_aca_catalog(stars=stars, dark=DARK40, raise_exc=True, **STD_INFO)
+
+    # Fake stars do not have an agasc_file attribute
+    assert "agasc_file" not in aca.stars.meta
 
     aca2 = pickle.loads(pickle.dumps(aca))
 

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -88,7 +88,7 @@ def test_get_aca_catalog_20603_with_supplement():
 
 
 @pytest.mark.skipif(not HAS_SC_ARCHIVE, reason="Test requires starcheck archive")
-def test_get_aca_catalog_20603():
+def test_get_aca_catalog_20603(proseco_agasc_1p7):
     """Put it all together.  Regression test for selected stars."""
     # Force not using a bright star so there is a GUI-only (not BOT) star
     aca = get_aca_catalog(
@@ -132,7 +132,7 @@ def test_get_aca_catalog_20603():
 
 
 @pytest.mark.skipif(not HAS_SC_ARCHIVE, reason="Test requires starcheck archive")
-def test_get_aca_catalog_20259():
+def test_get_aca_catalog_20259(proseco_agasc_1p7):
     """
     Test obsid 20259 which has two spoiled fids: HRC-2 is yellow and HRC-4 is red.
     Expectation is to choose fids 1, 2, 3 (not 4).
@@ -750,7 +750,7 @@ def test_dark_property():
     assert aca.dark.mean() > aca.acqs.dark.mean()
 
 
-def test_dense_star_field_regress():
+def test_dense_star_field_regress(proseco_agasc_1p7):
     """
     Test getting stars at the most dense star field in the sky.  Taken from:
 
@@ -867,7 +867,7 @@ def test_report_from_objects(tmpdir):
         assert len(list(outdir.glob("*.png"))) > 0
 
 
-def test_force_catalog_from_starcheck():
+def test_force_catalog_from_starcheck(proseco_agasc_1p7):
     """
     Test forcing a catalog from starcheck output.
     """

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import agasc
 import numpy as np
 import pytest
+import tables
 from astropy.io import ascii
+from packaging.version import Version
 
 from proseco import get_aca_catalog
 
@@ -22,10 +24,13 @@ from ..core import (
 from ..guide import GuideTable
 
 
-def test_agasc_gt_1p7():
+def test_agasc_1p8_or_later():
     """Check that AGASC 1.8 or later (including RC's) is being used."""
     agasc_file = agasc.get_agasc_filename()
-    assert Path(agasc_file).name.startswith("proseco_agasc_1p8")
+    with tables.open_file(agasc_file) as h5:
+        version = Version(h5.root.data.attrs["version"].replace("p", "."))
+    assert version.major == 1
+    assert version.minor >= 8
 
 
 def test_agasc_1p7(miniagasc_1p7):

--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pickle
+from pathlib import Path
 
 import agasc
 import numpy as np
@@ -21,7 +22,13 @@ from ..core import (
 from ..guide import GuideTable
 
 
-def test_agasc_1p7():
+def test_agasc_gt_1p7():
+    """Check that AGASC 1.8 or later (including RC's) is being used."""
+    agasc_file = agasc.get_agasc_filename()
+    assert Path(agasc_file).name.startswith("proseco_agasc_1p8")
+
+
+def test_agasc_1p7(miniagasc_1p7):
     """
     Ensure that AGASC 1.7 is being used.
     """
@@ -128,7 +135,7 @@ def test_box_greater():
     assert not box1 > (11, 16)
 
 
-def test_get_kwargs_from_starcheck_text():
+def test_get_kwargs_from_starcheck_text(proseco_agasc_1p7):
     text = """
     OBSID: 21071  Kapteyn's Star         ACIS-S SIM Z offset:0     (0.00mm) Grating: NONE
     RA, Dec, Roll (deg):    77.976747   -45.066796    85.007351

--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -159,7 +159,7 @@ def test_fid_spoiling_acq(dither_z):
     assert repr(fids5.cand_fids).splitlines() == exp
 
 
-def test_fid_mult_spoilers():
+def test_fid_mult_spoilers(proseco_agasc_1p7):
     """
     Test of fix for bug #54.  19605 and 20144 were previous crashing.
     """

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -34,7 +34,7 @@ HAS_SC_ARCHIVE = Path(mica.starcheck.starcheck.FILES["data_root"]).exists()
 os.environ[agasc.SUPPLEMENT_ENABLED_ENV] = "False"
 
 
-def test_select():
+def test_select(proseco_agasc_1p7):
     """
     Regression test that 5 expected agasc ids are selected at an arbitrary ra/dec/roll .
     """
@@ -46,7 +46,7 @@ def test_select():
 
 
 @pytest.mark.skipif(not HAS_SC_ARCHIVE, reason="Test requires starcheck archive")
-def test_obsid_19461():
+def test_obsid_19461(proseco_agasc_1p7):
     """
     Regression tests that 5 expected agasc ids are selected in a poor star field
     corresponding to obsid 19461.
@@ -131,7 +131,7 @@ def test_box_mag_spoiler():
     assert 688523960 not in selected2["id"]
 
 
-def test_region_contrib():
+def test_region_contrib(proseco_agasc_1p7):
     """Regression test of stars rejected by contributing starlight to readout region.
 
     Scenario test for too much light contribution by a spoiler star unto the

--- a/proseco/tests/test_mon_full_cat.py
+++ b/proseco/tests/test_mon_full_cat.py
@@ -62,7 +62,7 @@ def test_monitor_input_processing_ra_dec(stars):
     assert mon["id"] == 1000
 
 
-def test_monitor_mon_fixed_auto():
+def test_monitor_mon_fixed_auto(proseco_agasc_1p7):
     """In this case the MON_TRACK slot is not near a star"""
     monitors = [
         [-1700, 1900, MonCoord.YAGZAG, 7.5, MonFunc.MON_FIXED],

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore:'soft_unicode' has been renamed to 'soft_str'
-    ignore:`np.object` is a deprecated alias for the builtin `object`


### PR DESCRIPTION
## Description

This allows specifying the AGASC HDF5 that gets used in star selection via the `AGASC_HDF5_FILE` environment variable. If that is not set then it defaults to `<AGASC_DIR>/proseco_agasc_<latest>.h5`.
- `<AGASC_DIR>` is the `AGASC_DIR` environment variable or `$SKA/data/agasc`.
- The latest version of proseco_agasc is determined by the `agasc` package. 

This PR requires https://github.com/sot/agasc/pull/155.

As a bonus, I searched for `os.environ` in the code and documented all the environment variables that are used in proseco.

To do:
- [x] Add `AGASC_DIR` as a relevant env var.
- [x] Build the docs and confirm they look OK.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
With the git repo for https://github.com/sot/agasc/pull/155 in the PYTHONPATH:
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

#### Manual test of AGASC file
In my `$SKA/data/agasc`:
```
agasc1p7.h5
agasc1p8rc3.h5
agasc1p8rc4.h5
agasc1p8rc5.h5
agasc_healpix_1p7.h5
agasc_supplement.h5
miniagasc.h5
miniagasc_1p6.h5
miniagasc_1p7.h5
proseco_agasc_1p7.h5
proseco_agasc_1p8rc4.h5
```
Script:
```
from proseco.tests.test_common import STD_INFO
from proseco import get_aca_catalog
aca = get_aca_catalog(**STD_INFO)
print(aca.agasc_file)
```
Output:
```
/Users/aldcroft/ska/data/agasc/proseco_agasc_1p7.h5
```
Now make a temporary link from `proseco_agasc_1p8rc4.h5` to `proseco_agasc_1p8.h5`
New output:
```
/Users/aldcroft/ska/data/agasc/proseco_agasc_1p8.h5
```

