### PR TITLE
Rename a test so error isn't in the name

### DIFF
--- a/proseco/tests/test_fid.py
+++ b/proseco/tests/test_fid.py
@@ -81,7 +81,7 @@ def test_get_fid_pos_with_offsets(monkeypatch):
     assert np.all(zang1 == zang4)
 
 
-def test_get_fid_pos_errors(monkeypatch):
+def test_get_fid_pos_errs(monkeypatch):
     # Confirm if env var is set to 'True' and t_ccd and date not specified, then
     # there's an error.
     monkeypatch.setenv("PROSECO_ENABLE_FID_OFFSET", "True")


### PR DESCRIPTION
## Description

Change test name "test_get_fid_pos_errors" to "test_get_fid_pos_errs" .

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This works better with ska_testr default log filters on errors

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
