### PR TITLE
Add Row type aliases

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -10,10 +10,11 @@ import time
 import warnings
 from copy import copy
 from pathlib import Path
+from typing import TypeAlias
 
 import agasc
 import numpy as np
-from astropy.table import Column, Table
+from astropy.table import Column, Row, Table
 from chandra_aca.aca_image import AcaPsfLibrary
 from chandra_aca.transform import (
     count_rate_to_mag,
@@ -49,6 +50,9 @@ def to_python(val):
 # Row and column indices of ACA image background pixels
 _ROWB = np.array([0, 0, 0, 0, 7, 7, 7, 7])
 _COLB = np.array([0, 1, 6, 7, 0, 1, 6, 7])
+
+ACACatalogTableRow: TypeAlias = Row
+StarsTableRow: TypeAlias = Row
 
 
 def table_to_html(tbl):


### PR DESCRIPTION
## Description

This is a trivial PR to add type aliases for a couple of `Row` types. This is just to provide a type annotation that helps distinguish between a row in a `StarsTable` and and a row in an `ACACatalogTable`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  proseco git:(row-type-aliases) git rev-parse HEAD                 
d90681ec916fe0ab3e43d975130694402320c66d
(ska3) ➜  proseco git:(row-type-aliases) pytest
======================================================== test session starts ========================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 165 items                                                                                                                 

proseco/tests/test_acq.py ....................................                                                                [ 21%]
proseco/tests/test_catalog.py ..........................................                                                      [ 47%]
proseco/tests/test_core.py ...........................                                                                        [ 63%]
proseco/tests/test_diff.py ......                                                                                             [ 67%]
proseco/tests/test_fid.py ...............                                                                                     [ 76%]
proseco/tests/test_guide.py ...................................                                                               [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                                       [100%]

======================================================= 165 passed in 33.84s ========================================================
```

Independent check of unit tests by Jean
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
