### PR TITLE
pass ACAImage to np.percentile as an np.array, to circumvent ACAImage…

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -627,7 +627,9 @@ class GuideTable(ACACatalogTable):
 
         # Check for star spoilers (by light) background and edge
         if stage["ASPQ1Lim"] > 0:
-            bg_pix_thresh = np.percentile(dark, stage["Spoiler"]["BgPixThresh"])
+            bg_pix_thresh = np.percentile(
+                np.asarray(dark), stage["Spoiler"]["BgPixThresh"]
+            )
             reg_frac = stage["Spoiler"]["RegionFrac"]
             bg_spoil, reg_spoil, light_rej = check_spoil_contrib(
                 cand_guides, ok, stars, reg_frac, bg_pix_thresh


### PR DESCRIPTION
This PR is not really intended to be merged, unless we decide not to fix the corresponding issue in chandra_aca.

Proseco tests currently fail in Ska3 Speedy, and this PR props proseco so the test does not fail. The real cause of the failure is that `chandra_aca.aca_image.ACAImage` does not support ellipsis in slicing (sot/chandra_aca/issues/165).

## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
