### PR TITLE
WIP: Don't allow overlapping acq boxes 

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -692,22 +692,24 @@ class AcqTable(ACACatalogTable):
 
                 # If this box size could overlap with the box of an already selected star
                 # then skip it.
-                has_overlap = False
-                for other_idx, halfw2 in zip(acq_indices, box_sizes):
-                    other_acq = cand_acqs[other_idx]
-                    overlap_pad = 20
-                    halfw1 = box_size
-                    y1, z1 = acq["yang"], acq["zang"]
-                    y2, z2 = other_acq["yang"], other_acq["zang"]
-                    if (abs(y1 - y2) < halfw1 + halfw2 + overlap_pad
-                        and abs(z1 - z2) < halfw1 + halfw2 + overlap_pad):
-                            self.log(f"Skipping Star {acq_idx:2d} box {box_size:3d}, "
-                                 "possible overlap with already selected star "
-                                f"{other_acq['id']}", level=2)
-                            has_overlap = True
-                            break
-                if has_overlap:
-                    continue
+                if (("PROSECO_ACQ_OVERLAP_PENALTY" in os.environ)
+                    & (os.environ["PROSECO_ACQ_OVERLAP_PENALTY"] == "True")):
+                    has_overlap = False
+                    for other_idx, halfw2 in zip(acq_indices, box_sizes):
+                        other_acq = cand_acqs[other_idx]
+                        overlap_pad = 20
+                        halfw1 = box_size
+                        y1, z1 = acq["yang"], acq["zang"]
+                        y2, z2 = other_acq["yang"], other_acq["zang"]
+                        if (abs(y1 - y2) < halfw1 + halfw2 + overlap_pad
+                            and abs(z1 - z2) < halfw1 + halfw2 + overlap_pad):
+                                self.log(f"Skipping Star {acq_idx:2d} box {box_size:3d}, "
+                                    "possible overlap with already selected star "
+                                    f"{other_acq['id']}", level=2)
+                                has_overlap = True
+                                break
+                    if has_overlap:
+                        continue
 
                 p_acq = p_acqs_for_box[acq_idx]
                 accepted = p_acq > min_p_acq

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -55,7 +55,6 @@ def box_overlap(y1, z1, halfw1, y2, z2, halfw2, overlap_pad=20):
     )
 
 
-
 def load_maxmags() -> dict:
     """
     Load maxmags from disk.
@@ -711,7 +710,7 @@ class AcqTable(ACACatalogTable):
 
                 # If this box size could overlap with the box of an already selected star
                 # then skip it.
-                if (os.environ.get("PROSECO_ACQ_OVERLAP_PENALTY") == "True"):
+                if os.environ.get("PROSECO_ACQ_OVERLAP_PENALTY") == "True":
                     has_overlap = False
                     for other_idx, halfw2 in zip(acq_indices, box_sizes):
                         other_acq = cand_acqs[other_idx]
@@ -719,11 +718,14 @@ class AcqTable(ACACatalogTable):
                         y1, z1 = acq["yang"], acq["zang"]
                         y2, z2 = other_acq["yang"], other_acq["zang"]
                         if box_overlap(y1, z1, halfw1, y2, z2, halfw2):
-                                self.log(f"Skipping Star {acq_idx:2d} box {box_size:3d}, "
-                                    "possible overlap with already selected star "
-                                    f"{other_acq['id']}", level=2)
-                                has_overlap = True
-                                break
+                            self.log(
+                                f"Skipping Star {acq_idx:2d} box {box_size:3d}, "
+                                "possible overlap with already selected star "
+                                f"{other_acq['id']}",
+                                level=2,
+                            )
+                            has_overlap = True
+                            break
                     if has_overlap:
                         continue
 
@@ -939,12 +941,15 @@ class AcqTable(ACACatalogTable):
 
             # Check for overlapping boxes and if so, reduce the probability of
             # acquiring the star.
-            if (os.environ.get("PROSECO_ACQ_OVERLAP_PENALTY") == "True"):
-                    penalties = self.get_overlap_penalties()
-                    if np.count_nonzero(penalties):
-                        self.log("Overlapping boxes detected, applying penalty", level=1)
-                        self.log(f"{penalties}", level=1)
-                        p_acqs = [p_acq * (1 - penalty) for p_acq, penalty in zip(p_acqs, penalties)]
+            if os.environ.get("PROSECO_ACQ_OVERLAP_PENALTY") == "True":
+                penalties = self.get_overlap_penalties()
+                if np.count_nonzero(penalties):
+                    self.log("Overlapping boxes detected, applying penalty", level=1)
+                    self.log(f"{penalties}", level=1)
+                    p_acqs = [
+                        p_acq * (1 - penalty)
+                        for p_acq, penalty in zip(p_acqs, penalties)
+                    ]
 
             p_n_cum = prob_n_acq(p_acqs)[1]  # This returns (p_n, p_n_cum)
 

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -690,6 +690,25 @@ class AcqTable(ACACatalogTable):
                 if acq["id"] in self.exclude_ids:
                     continue
 
+                # If this box size could overlap with the box of an already selected star
+                # then skip it.
+                has_overlap = False
+                for other_idx, halfw2 in zip(acq_indices, box_sizes):
+                    other_acq = cand_acqs[other_idx]
+                    overlap_pad = 20
+                    halfw1 = box_size
+                    y1, z1 = acq["yang"], acq["zang"]
+                    y2, z2 = other_acq["yang"], other_acq["zang"]
+                    if (abs(y1 - y2) < halfw1 + halfw2 + overlap_pad
+                        and abs(z1 - z2) < halfw1 + halfw2 + overlap_pad):
+                            self.log(f"Skipping Star {acq_idx:2d} box {box_size:3d}, "
+                                 "possible overlap with already selected star "
+                                f"{other_acq['id']}", level=2)
+                            has_overlap = True
+                            break
+                if has_overlap:
+                    continue
+
                 p_acq = p_acqs_for_box[acq_idx]
                 accepted = p_acq > min_p_acq
                 status = "ACCEPTED" if accepted else "rejected"

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -1120,6 +1120,32 @@ class AcqTable(ACACatalogTable):
 
             idx = self.get_id_idx(acqs_id_ok[idx_worst])
 
+            # Does the candidate overlap with any of the selected stars (except
+            # the worst one?
+            if os.environ.get("PROSECO_ACQ_OVERLAP_PENALTY") == "True":
+                has_overlap = False
+                for selected_id in acqs_id_ok:
+                    if selected_id == acqs_id_ok[idx_worst]:
+                        continue
+                    selected_star = self.get_id(selected_id)
+                    if box_overlap(
+                        cand_acq["yang"],
+                        cand_acq["zang"],
+                        180,
+                        selected_star["yang"],
+                        selected_star["zang"],
+                        180,
+                    ):
+                        has_overlap = True
+                        break
+
+                if has_overlap:
+                    self.log(
+                        f"Skipping candidate {cand_id} due to overlap with already selected star",
+                        id=cand_id,
+                    )
+                    continue
+
             self.log(
                 "Trying to use {} mag={:.2f} to replace idx={} with p_acq={:.3f}".format(
                     cand_id, cand_acq["mag"], idx, p_acqs[idx_worst]

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -692,8 +692,7 @@ class AcqTable(ACACatalogTable):
 
                 # If this box size could overlap with the box of an already selected star
                 # then skip it.
-                if (("PROSECO_ACQ_OVERLAP_PENALTY" in os.environ)
-                    & (os.environ["PROSECO_ACQ_OVERLAP_PENALTY"] == "True")):
+                if (os.environ.get("PROSECO_ACQ_OVERLAP_PENALTY") == "True"):
                     has_overlap = False
                     for other_idx, halfw2 in zip(acq_indices, box_sizes):
                         other_acq = cand_acqs[other_idx]
@@ -929,8 +928,7 @@ class AcqTable(ACACatalogTable):
 
             # Check for overlapping boxes and if so, reduce the probability of
             # acquiring the star.
-            if (("PROSECO_ACQ_OVERLAP_PENALTY" in os.environ)
-                & (os.environ["PROSECO_ACQ_OVERLAP_PENALTY"] == "True")):
+            if (os.environ.get("PROSECO_ACQ_OVERLAP_PENALTY") == "True"):
                     penalties = self.get_overlap_penalties()
                     if np.count_nonzero(penalties):
                         self.log("Overlapping boxes detected, applying penalty", level=1)

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -669,9 +669,9 @@ class ACACatalogTable(BaseCatalogTable):
         # Set pixel regions from ACA.bad_pixels to have acqs.dark=700000 (5.0 mag
         # star) per pixel.
         for r0, r1, c0, c1 in ACA.bad_pixels:
-            self._dark[
-                r0 + 512 : r1 + 513, c0 + 512 : c1 + 513
-            ] = ACA.bad_pixel_dark_current
+            self._dark[r0 + 512 : r1 + 513, c0 + 512 : c1 + 513] = (
+                ACA.bad_pixel_dark_current
+            )
 
     def set_attrs_from_kwargs(self, **kwargs):
         for name, val in kwargs.items():

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -159,9 +159,9 @@ class GuideTable(ACACatalogTable):
             dr = int(4 + np.ceil(self.dither.row if is_track else 0))
             dc = int(4 + np.ceil(self.dither.col if is_track else 0))
             row, col = int(monitor["row"]) + 512, int(monitor["col"]) + 512
-            self.dark[
-                row - dr : row + dr, col - dc : col + dc
-            ] = ACA.bad_pixel_dark_current  # noqa
+            self.dark[row - dr : row + dr, col - dc : col + dc] = (
+                ACA.bad_pixel_dark_current
+            )  # noqa
 
             # Reduce n_guide for each MON. On input the n_guide arg is the
             # number of GUI + MON, but for guide selection we need to make the

--- a/proseco/monitor.py
+++ b/proseco/monitor.py
@@ -186,9 +186,9 @@ class MonTable(ACACatalogTable):
                     "MFX" if monitor["function"] == MonFunc.MON_FIXED else "MTR"
                 )
                 mon["sz"] = "8x8"
-                mon[
-                    "dim"
-                ] = -999  # Set an obviously bad value for DTS, gets fixed later.
+                mon["dim"] = (
+                    -999
+                )  # Set an obviously bad value for DTS, gets fixed later.
                 mon["res"] = 0
                 mon["halfw"] = 20
                 mon["maxmag"] = ACA.monitor_maxmag


### PR DESCRIPTION
## Description

Penalize acquisition box overlaps by setting p_acq to 0 for those stars and not allowing stars to overlap with already selected star when building up the catalog.

This needs some more help in optimization (it would be nice if optimization could solve for the case where a change to a small box allows one to bring in another strong candidate in a small box as they would now be non-overlapping).  And this code presently throws an error if you try to force-include both stars in an overlapping pair (not sure if we need to code around that or not).

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
