### PR TITLE
Respect include_ids_guide in combination optimization

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -391,7 +391,6 @@ class GuideTable(ACACatalogTable):
             self.log("All guide stars are force-included")
             return stage_cands[forced]
 
-
         # This subtracts the number of unique force-included stars as they are not
         # part of the combination selection process.
         choose_m = min(len(stage_cands), self.n_guide) - n_forced

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -609,6 +609,30 @@ def test_guides_include_bad():
     assert "cannot include star id=20" in str(err)
 
 
+def test_guides_include_close():
+    """
+    Test force include stars where they would not be selected due to
+    clustering.
+    """
+    stars = StarsTable.empty()
+
+    stars.add_fake_constellation(
+        mag=[7.0, 7.0, 7.0, 7.0, 7.0],
+        id=[5, 6, 7, 8, 9],
+        size=2000,
+        n_stars=5)
+
+    stars.add_fake_star(mag=11.0, yang=100, zang=100, id=1)
+    stars.add_fake_star(mag=11.0, yang=-100, zang=-100, id=2)
+    stars.add_fake_star(mag=11.0, yang=100, zang=-100, id=3)
+    stars.add_fake_star(mag=11.0, yang=-100, zang=100, id=4)
+
+    include_ids = [1, 2, 3, 4]
+    guides = get_guide_catalog(**mod_std_info(n_guide=5),
+                               stars=stars, include_ids=include_ids)
+    assert np.all(np.in1d(include_ids, guides["id"]))
+
+
 @pytest.mark.parametrize("dither", dither_cases)
 def test_edge_star(dither):
     """

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -22,6 +22,7 @@ from ..guide import (
     get_ax_range,
     get_guide_catalog,
     get_pixmag_for_offset,
+    run_select_checks,
 )
 from ..report_guide import make_report
 from .test_common import DARK40, OBS_INFO, STD_INFO, mod_std_info
@@ -618,19 +619,36 @@ def test_guides_include_close():
 
     stars.add_fake_constellation(
         mag=[7.0, 7.0, 7.0, 7.0, 7.0],
-        id=[5, 6, 7, 8, 9],
+        id=[25, 26, 27, 28, 29],
         size=2000,
         n_stars=5)
 
-    stars.add_fake_star(mag=11.0, yang=100, zang=100, id=1)
-    stars.add_fake_star(mag=11.0, yang=-100, zang=-100, id=2)
-    stars.add_fake_star(mag=11.0, yang=100, zang=-100, id=3)
-    stars.add_fake_star(mag=11.0, yang=-100, zang=100, id=4)
+    stars.add_fake_star(mag=11.0, yang=100, zang=100, id=21)
+    stars.add_fake_star(mag=11.0, yang=-100, zang=-100, id=22)
+    stars.add_fake_star(mag=11.0, yang=100, zang=-100, id=23)
+    stars.add_fake_star(mag=11.0, yang=-100, zang=100, id=24)
 
-    include_ids = [1, 2, 3, 4]
-    guides = get_guide_catalog(**mod_std_info(n_guide=5),
-                               stars=stars, include_ids=include_ids)
-    assert np.all(np.in1d(include_ids, guides["id"]))
+    cat1 = get_guide_catalog(**mod_std_info(n_guide=5),
+                             stars=stars)
+
+    # Run the cluster checks and confirm all 3 pass
+    cat1_pass, _ = run_select_checks(cat1)
+    assert cat1_pass == 3
+
+    # Confirm that only bright stars are used
+    assert np.count_nonzero(cat1["mag"] == 7.0) == 5
+
+    # Force include the faint 4 stars that are also close together
+    include_ids = [21, 22, 23, 24]
+    cat2 = get_guide_catalog(**mod_std_info(n_guide=5),
+                             stars=stars, include_ids_guide=include_ids)
+
+    # Run the cluster checks and confirm all 3 fail
+    cat2_pass, _ = run_select_checks(cat2)
+    assert cat2_pass == 0
+    assert np.all(np.in1d(include_ids, cat2["id"]))
+    # And confirm that only one of the bright stars is used
+    assert np.count_nonzero(cat2["mag"] == 7.0) == 1
 
 
 @pytest.mark.parametrize("dither", dither_cases)

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -618,18 +618,15 @@ def test_guides_include_close():
     stars = StarsTable.empty()
 
     stars.add_fake_constellation(
-        mag=[7.0, 7.0, 7.0, 7.0, 7.0],
-        id=[25, 26, 27, 28, 29],
-        size=2000,
-        n_stars=5)
+        mag=[7.0, 7.0, 7.0, 7.0, 7.0], id=[25, 26, 27, 28, 29], size=2000, n_stars=5
+    )
 
     stars.add_fake_star(mag=11.0, yang=100, zang=100, id=21)
     stars.add_fake_star(mag=11.0, yang=-100, zang=-100, id=22)
     stars.add_fake_star(mag=11.0, yang=100, zang=-100, id=23)
     stars.add_fake_star(mag=11.0, yang=-100, zang=100, id=24)
 
-    cat1 = get_guide_catalog(**mod_std_info(n_guide=5),
-                             stars=stars)
+    cat1 = get_guide_catalog(**mod_std_info(n_guide=5), stars=stars)
 
     # Run the cluster checks and confirm all 3 pass
     cat1_pass, _ = run_select_checks(cat1)
@@ -640,8 +637,9 @@ def test_guides_include_close():
 
     # Force include the faint 4 stars that are also close together
     include_ids = [21, 22, 23, 24]
-    cat2 = get_guide_catalog(**mod_std_info(n_guide=5),
-                             stars=stars, include_ids_guide=include_ids)
+    cat2 = get_guide_catalog(
+        **mod_std_info(n_guide=5), stars=stars, include_ids_guide=include_ids
+    )
 
     # Run the cluster checks and confirm all 3 fail
     cat2_pass, _ = run_select_checks(cat2)


### PR DESCRIPTION
## Description

Respect include_ids_guide in combination optimization

Fixes bug noticed on prelim review of obsid 26719 that the combination optimization to avoid close guide stars ignored the include_ids_guide.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

```
(ska3-masters) flame:proseco jean$ pytest
================================================ test session starts ================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 167 items                                                                                                 

proseco/tests/test_acq.py .....................................                                               [ 22%]
proseco/tests/test_catalog.py ..........................................                                      [ 47%]
proseco/tests/test_core.py ...........................                                                        [ 63%]
proseco/tests/test_diff.py ......                                                                             [ 67%]
proseco/tests/test_fid.py ...............                                                                     [ 76%]
proseco/tests/test_guide.py ....................................                                              [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                       [100%]

=============================================== 167 passed in 30.78s ================================================
(ska3-masters) flame:proseco jean$ git rev-parse HEAD
480a134e9dde52303308f57c1567f173b91f6bd0
```


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Previously 26719 did this:
```
acas = pickle.load(gzip.open('/Users/jean/APR0824_aca_question_2024_093_16_03_57_688.pkl.gz'))
acas[26719].pprint()
slot idx     id    type  sz p_acq  mag  maxmag   yang     zang   dim res halfw
---- --- --------- ---- --- ----- ----- ------ -------- -------- --- --- -----
   0   1         2  FID 8x8 0.000  7.00   8.00  -767.76 -1745.27   1   1    25
   1   2         4  FID 8x8 0.000  7.00   8.00  2145.67   163.39   1   1    25
   2   3         5  FID 8x8 0.000  7.00   8.00 -1820.84   156.93   1   1    25
   3   4 188504240  BOT 8x8 0.978  5.37   6.87   476.61  1572.62  16   1   100
   4   5 188744824  BOT 8x8 0.965  8.32   9.82 -2170.78  2349.37  16   1   100
   5   6 188747592  BOT 8x8 0.848  9.51  11.01 -1082.05   886.42  16   1   100
   6   7 188747008  BOT 8x8 0.772  9.75  11.19 -1181.01   601.06  16   1   100
   7   8 188356208  BOT 8x8 0.753 10.02  11.20  1357.75 -1241.32   8   1    60
   0   9 188488808  ACQ 8x8 0.768  9.97  11.20  -346.98  1127.42   8   1    60
   1  10 188757072  ACQ 8x8 0.582 10.31  11.20 -2383.87 -1490.79   8   1    60
   2  11 188501440  ACQ 8x8 0.589 10.39  11.20  1414.78   616.57   8   1    60
args = acas[26719].call_args.copy()
args['n_guide'] = 4
args['include_ids_guide'] = [188744824, 188747592, 188747008, 188356208]
cat = proseco.get_aca_catalog(**args)
cat.pprint()
slot idx     id    type  sz p_acq  mag  maxmag   yang     zang   dim res halfw
---- --- --------- ---- --- ----- ----- ------ -------- -------- --- --- -----
   0   1         2  FID 8x8 0.000  7.00   8.00  -767.76 -1745.27   1   1    25
   1   2         4  FID 8x8 0.000  7.00   8.00  2145.67   163.39   1   1    25
   2   3         5  FID 8x8 0.000  7.00   8.00 -1820.84   156.93   1   1    25
   3   4 188504240  BOT 8x8 0.978  5.37   6.87   476.61  1572.62  16   1   100
   4   5 188744824  BOT 8x8 0.965  8.32   9.82 -2170.78  2349.37  16   1   100
   5   6 188747592  BOT 8x8 0.848  9.51  11.01 -1082.05   886.42  16   1   100
   6   7 188356208  BOT 8x8 0.753 10.02  11.20  1357.75 -1241.32   8   1    60
   0   8 188747008  ACQ 8x8 0.772  9.75  11.19 -1181.01   601.06  16   1   100
   1   9 188488808  ACQ 8x8 0.768  9.97  11.20  -346.98  1127.42   8   1    60
   2  10 188757072  ACQ 8x8 0.582 10.31  11.20 -2383.87 -1490.79   8   1    60
   7  11 188501440  ACQ 8x8 0.589 10.39  11.20  1414.78   616.57   8   1    60
```

With this PR the 4 stars requested are used
```
In [3]: acas = pickle.load(gzip.open('/Users/jean/APR0824_aca_question_2024_093_16_03_57_688.pkl.gz'))
In [4]: args = acas[26719].call_args.copy()
In [5]: args['n_guide'] = 4
In [6]: args['include_ids_guide'] = [188744824, 188747592, 188747008, 188356208]
In [9]: cat = proseco.get_aca_catalog(**args)

In [10]: cat
Out[10]: 
<ACATable length=11>
 slot  idx      id    type  sz   p_acq    mag    maxmag   yang     zang    dim   res  halfw
int64 int64   int64   str3 str3 float64 float64 float64 float64  float64  int64 int64 int64
----- ----- --------- ---- ---- ------- ------- ------- -------- -------- ----- ----- -----
    0     1         2  FID  8x8   0.000    7.00    8.00  -767.76 -1745.27     1     1    25
    1     2         4  FID  8x8   0.000    7.00    8.00  2145.67   163.39     1     1    25
    2     3         5  FID  8x8   0.000    7.00    8.00 -1820.84   156.93     1     1    25
    3     4 188744824  BOT  8x8   0.965    8.32    9.82 -2170.78  2349.37    16     1   100
    4     5 188747592  BOT  8x8   0.848    9.51   11.01 -1082.05   886.42    16     1   100
    5     6 188747008  BOT  8x8   0.772    9.75   11.19 -1181.01   601.06    16     1   100
    6     7 188356208  BOT  8x8   0.753   10.02   11.20  1357.75 -1241.32     8     1    60
    0     8 188504240  ACQ  8x8   0.978    5.37    6.87   476.61  1572.62    16     1   100
    1     9 188488808  ACQ  8x8   0.768    9.97   11.20  -346.98  1127.42     8     1    60
    2    10 188757072  ACQ  8x8   0.582   10.31   11.20 -2383.87 -1490.79     8     1    60
    7    11 188501440  ACQ  8x8   0.589   10.39   11.20  1414.78   616.57     8     1    60
```

As a regression test, I reselected the catalogs from the loads from
"2023:001" to "2024:175" (using the pickle args) and confirmed no catalog diffs between this PR and current master.