### PR TITLE
Respect include_ids_guide in combination optimization (alternate implementation)

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -402,12 +402,18 @@ class GuideTable(ACACatalogTable):
         choose_m = min(len(stage_cands), self.n_guide)
 
         n_tries = 0
-        for n_tries, comb in enumerate(
-            index_combinations(len(stage_cands), choose_m), start=1
-        ):
+        for comb in index_combinations(len(stage_cands), choose_m):
             cands = stage_cands[
                 list(comb)
             ]  # (note that [(1,2)] is not the same as list((1,2))
+
+            # If there are any include_ids, then the selected stars must include them.
+            # If not, skip this combination.
+            if self.include_ids and not set(self.include_ids).issubset(cands["id"]):
+                continue
+
+            n_tries += 1
+
             n_pass, n_tests = run_select_checks(
                 cands
             )  # This function knows how many tests get run


### PR DESCRIPTION
## Description

Respect `include_ids_guide` in combination optimization. The updated test is taken from #396 and this PR supersedes that one.

Fixes bug noticed on prelim review of obsid 26719 that the combination optimization to avoid close guide stars ignored the include_ids_guide.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  proseco git:(force-guide-alt) git rev-parse HEAD                                                        
d140c060348fe1ec01a524d60d3c887b119049b2
(ska3) ➜  proseco git:(force-guide-alt) pytest 
==================================================== test session starts =====================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collecting ... Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) instructions.
Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) instructions.
collected 167 items                                                                                                          

proseco/tests/test_acq.py .....................................                                                        [ 22%]
proseco/tests/test_catalog.py ..........................................                                               [ 47%]
proseco/tests/test_core.py ...........................                                                                 [ 63%]
proseco/tests/test_diff.py ......                                                                                      [ 67%]
proseco/tests/test_fid.py ...............                                                                              [ 76%]
proseco/tests/test_guide.py ....................................                                                       [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                                [100%]

==================================================== 167 passed in 28.38s ====================================================
```
Independent check of unit tests by Jean
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
d140c060348fe1ec01a524d60d3c887b119049b2
ska3-jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 167 items                                                            

proseco/tests/test_acq.py .....................................          [ 22%]
proseco/tests/test_catalog.py .......................................... [ 47%]
                                                                         [ 47%]
proseco/tests/test_core.py ...........................                   [ 63%]
proseco/tests/test_diff.py ......                                        [ 67%]
proseco/tests/test_fid.py ...............                                [ 76%]
proseco/tests/test_guide.py ....................................         [ 97%]
proseco/tests/test_mon_full_cat.py ....                                  [100%]

```

### Functional tests
Functional test copied from #396
```
>>> import pickle
>>> import gzip
>>> acas = pickle.load(
...     gzip.open(
...         "/Users/aldcroft/Downloads/APR0824_aca_question_2024_093_16_03_57_688.pkl.gz"
...     )
... )
>>> acas[26719].pprint()
...
slot idx     id    type  sz p_acq  mag  maxmag   yang     zang   dim res halfw
---- --- --------- ---- --- ----- ----- ------ -------- -------- --- --- -----
   0   1         2  FID 8x8 0.000  7.00   8.00  -767.76 -1745.27   1   1    25
   1   2         4  FID 8x8 0.000  7.00   8.00  2145.67   163.39   1   1    25
   2   3         5  FID 8x8 0.000  7.00   8.00 -1820.84   156.93   1   1    25
   3   4 188504240  BOT 8x8 0.978  5.37   6.87   476.61  1572.62  16   1   100
   4   5 188744824  BOT 8x8 0.965  8.32   9.82 -2170.78  2349.37  16   1   100
   5   6 188747592  BOT 8x8 0.848  9.51  11.01 -1082.05   886.42  16   1   100
   6   7 188747008  BOT 8x8 0.772  9.75  11.19 -1181.01   601.06  16   1   100
   7   8 188356208  BOT 8x8 0.753 10.02  11.20  1357.75 -1241.32   8   1    60
   0   9 188488808  ACQ 8x8 0.768  9.97  11.20  -346.98  1127.42   8   1    60
   1  10 188757072  ACQ 8x8 0.582 10.31  11.20 -2383.87 -1490.79   8   1    60
   2  11 188501440  ACQ 8x8 0.589 10.39  11.20  1414.78   616.57   8   1    60
>>> import proseco
>>> args = acas[26719].call_args.copy()
... args["n_guide"] = 4
... args["include_ids_guide"] = [188744824, 188747592, 188747008, 188356208]
... cat = proseco.get_aca_catalog(**args)
... cat.pprint()
...
slot idx     id    type  sz p_acq  mag  maxmag   yang     zang   dim res halfw
---- --- --------- ---- --- ----- ----- ------ -------- -------- --- --- -----
   0   1         2  FID 8x8 0.000  7.00   8.00  -767.76 -1745.27   1   1    25
   1   2         4  FID 8x8 0.000  7.00   8.00  2145.67   163.39   1   1    25
   2   3         5  FID 8x8 0.000  7.00   8.00 -1820.84   156.93   1   1    25
   3   4 188744824  BOT 8x8 0.965  8.32   9.82 -2170.78  2349.37  16   1   100
   4   5 188747592  BOT 8x8 0.851  9.50  11.00 -1082.05   886.42  16   1   100
   5   6 188747008  BOT 8x8 0.776  9.74  11.19 -1181.01   601.06  16   1   100
   6   7 188356208  BOT 8x8 0.752 10.02  11.20  1357.75 -1241.32   8   1    60
   0   8 188504240  ACQ 8x8 0.978  5.37   6.87   476.61  1572.62  16   1   100
   1   9 188488808  ACQ 8x8 0.772  9.95  11.20  -346.98  1127.42   8   1    60
   2  10 188757072  ACQ 8x8 0.582 10.31  11.20 -2383.87 -1490.79   8   1    60
   7  11 188501440  ACQ 8x8 0.589 10.39  11.20  1414.78   616.57   8   1    60

>>> >>> set(args["include_ids_guide"]).issubset(cat["id"])
True
```

