### PR TITLE
Factor out guide and acq candidates mask

### DIFF
--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -8,6 +8,7 @@ https://docs.google.com/presentation/d/1VtFKAW9he2vWIQAnb6unpK4u1bVAVziIdX9TnqRS
 import os
 import warnings
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 from chandra_aca.star_probs import (
@@ -34,6 +35,10 @@ from .core import (
     get_mag_std,
     pea_reject_image,
 )
+
+if TYPE_CHECKING:
+    from astropy.table import Table
+
 
 # See https://github.com/sot/skanb/blob/master/aca-acq/acq-fails-bright-stars.ipynb
 OVERLAP_P_ACQ_PENALTY = 0.7  # p_acq multiplier for search box overlap
@@ -176,6 +181,41 @@ def boxes_overlap(
             return out
 
     return 0
+
+
+def get_acq_candidates_mask(stars: "Table") -> np.ndarray:
+    """Get filter on ``stars`` for acceptable acquisition star candidates.
+
+    This does not include spatial filtering.
+
+    Parameters
+    ----------
+    stars : Table
+        Table of stars
+
+    Returns
+    -------
+    ok : np.array of bool
+        Mask of acceptable stars
+    """
+    # Allow for stars from proseco StarsTable.from_stars() with `mag` and `mag_err`,
+    # or native agasc.get_agasc_cone() stars table.
+    mag = stars["mag"] if "mag" in stars.colnames else stars["MAG_ACA"]
+    mag_err = (
+        stars["mag_err"] if "mag_err" in stars.colnames else stars["MAG_ACA_ERR"] / 100
+    )
+    ok = (
+        (stars["CLASS"] == 0)
+        & (mag > 5.3)
+        & (mag < 11.0)
+        & (~np.isclose(stars["COLOR1"], 0.7))
+        & (mag_err < 1.0)
+        & (stars["ASPQ1"] < 40)  # < 2 arcsec centroid offset due to nearby spoiler
+        & (stars["ASPQ2"] == 0)
+        & (stars["POS_ERR"] < 3000)  # Position error < 3.0 arcsec
+        & ((stars["VAR"] == -9999) | (stars["VAR"] == 5))  # Not known to vary > 0.2 mag
+    )
+    return ok
 
 
 def get_acq_catalog(obsid=0, **kwargs):
@@ -461,22 +501,7 @@ class AcqTable(ACACatalogTable):
         :returns: bool mask of acceptable stars
 
         """
-        ok = (
-            (stars["CLASS"] == 0)
-            & (stars["mag"] > 5.3)
-            & (stars["mag"] < 11.0)
-            & (~np.isclose(stars["COLOR1"], 0.7))
-            & (stars["mag_err"] < 1.0)
-            & (stars["ASPQ1"] < 40)  # Mag err < 1.0 mag
-            & (  # Less than 2 arcsec centroid offset due to nearby spoiler
-                stars["ASPQ2"] == 0
-            )
-            & (stars["POS_ERR"] < 3000)  # Proper motion less than 0.5 arcsec/yr
-            & (  # Position error < 3.0 arcsec
-                (stars["VAR"] == -9999) | (stars["VAR"] == 5)
-            )  # Not known to vary > 0.2 mag
-        )
-        return ok
+        return get_acq_candidates_mask(stars)
 
     def get_acq_candidates(self, stars, max_candidates=20) -> StarsTable:
         """

--- a/proseco/acq.py
+++ b/proseco/acq.py
@@ -211,7 +211,7 @@ def get_acq_candidates_mask(stars: "Table") -> np.ndarray:
         & (~np.isclose(stars["COLOR1"], 0.7))
         & (mag_err < 1.0)
         & (stars["ASPQ1"] < 40)  # < 2 arcsec centroid offset due to nearby spoiler
-        & (stars["ASPQ2"] == 0)
+        & (stars["ASPQ2"] == 0)  # Unknown proper motion, or PM < 500 milli-arcsec/year
         & (stars["POS_ERR"] < 3000)  # Position error < 3.0 arcsec
         & ((stars["VAR"] == -9999) | (stars["VAR"] == 5))  # Not known to vary > 0.2 mag
     )

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -115,6 +115,10 @@ def get_guide_candidates_mask(
     ----------
     stars : Table
         Table of stars
+    t_ccd : float
+        ACA CCD temperature (degC)
+    dyn_bgd : bool
+        Dynamic background enabled flag
 
     Returns
     -------

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -148,8 +148,8 @@ def get_guide_candidates_mask(
         & (mag > 5.2)
         & (mag < faint_mag_limit)
         & (mag_err < 1.0)
-        & (stars["ASPQ1"] < 20)  # Mag err < 1.0 mag
-        & (stars["ASPQ2"] == 0)  # Less than 1 arcsec offset from nearby spoiler
+        & (stars["ASPQ1"] < 20)  # Less than 1 arcsec offset from nearby spoiler
+        & (stars["ASPQ2"] == 0)  # Unknown proper motion, or PM < 500 milli-arcsec/year
         & (stars["POS_ERR"] < 1250)  # Position error < 1.25 arcsec
         & ((stars["VAR"] == -9999) | (stars["VAR"] == 5))  # Not known to vary > 0.2 mag
     )

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,3 +32,6 @@ lint.extend-ignore = [
     "C408", # Unnecessary `dict` call (rewrite as a literal)
     "B905", # `zip()` without an explicit `strict=` parameter
 ]
+"core.py" = [
+    "PLR1704", # Redefining argument with the local name
+]


### PR DESCRIPTION
## Description

This makes publicly-available versions of the guide and acq star candidates masks. These have previously been stuck in a class method that ended up getting copied and modified for application code.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds two new functions that are useful for external applications.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  proseco git:(factor-out-candidates-mask) git rev-parse HEAD                                                        
c683dac86fb19b12350c333e2080a5d4763825b5
(ska3) ➜  proseco git:(factor-out-candidates-mask) pytest
======================================================== test session starts ========================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 167 items                                                                                                                 

proseco/tests/test_acq.py .....................................                                                               [ 22%]
proseco/tests/test_catalog.py ..........................................                                                      [ 47%]
proseco/tests/test_core.py ...........................                                                                        [ 63%]
proseco/tests/test_diff.py ......                                                                                             [ 67%]
proseco/tests/test_fid.py ...............                                                                                     [ 76%]
proseco/tests/test_guide.py ....................................                                                              [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                                       [100%]

======================================================= 167 passed in 21.69s ========================================================
```

Independent check of unit tests by Jean
- [x] Linux

```
ska3-jeanconn-fido> git rev-parse HEAD
aeee4352722a4077a828637573c608c06bf27689
ska3-jeanconn-fido> pytest
======================================= test session starts ========================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 167 items                                                                                             

proseco/tests/test_acq.py .....................................                                           [ 22%]
proseco/tests/test_catalog.py ..........................................                                  [ 47%]
proseco/tests/test_core.py ...........................                                                    [ 63%]
proseco/tests/test_diff.py ......                                                                         [ 67%]
proseco/tests/test_fid.py ...............                                                                 [ 76%]
proseco/tests/test_guide.py ....................................                                          [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                   [100%]

======================================== 167 passed in 129.81s (0:02:09)
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Functionally tested in https://github.com/sot/chandra_aca/pull/170. In particular, test the handling of star catalogs without `mag` and `mag_err` columns.