### PR TITLE
Remove some agasc supplement bad star tests

### DIFF
--- a/proseco/tests/test_core.py
+++ b/proseco/tests/test_core.py
@@ -48,10 +48,8 @@ def test_agasc_1p7(miniagasc_1p7):
 
 
 def test_agasc_supplement():
-    assert len(bad_star_set) > 3300
+    assert len(bad_star_set) > 300
     assert 36178592 in bad_star_set  # From original starcheck list
-    assert 658160 in bad_star_set
-    assert 1248994952 in bad_star_set
 
 
 def test_box_init():

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,7 +2,7 @@ extend = "ruff-base.toml"
 
 # These are files to exclude for this project.
 extend-exclude = [
-  # "**/*.ipynb",  # commonly not ruff-compliant
+  "**/*.ipynb",  # commonly not ruff-compliant
 ]
 
 # These are rules that commonly cause many ruff warnings. Code will be improved by


### PR DESCRIPTION
## Description

Remove some agasc supplement bad star tests .  

This does not address the issue that maybe this test_agasc_supplement should be removed or updated to work with a static or versioned supplement.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue that the asserts in the test were not valid after removing some stars from the bad list.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac arm64
```
(ska3) flame:proseco jean$ git rev-parse head
a25c3a78e4321590f33082062b2d461607dfbb5e
(ska3) flame:proseco jean$ pytest 
========================================================================================== test session starts ==========================================================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 167 items                                                                                                                                                                                     

proseco/tests/test_acq.py .....................................                                                                                                                                   [ 22%]
proseco/tests/test_catalog.py ..........................................                                                                                                                          [ 47%]
proseco/tests/test_core.py ...........................                                                                                                                                            [ 63%]
proseco/tests/test_diff.py ......                                                                                                                                                                 [ 67%]
proseco/tests/test_fid.py ...............                                                                                                                                                         [ 76%]
proseco/tests/test_guide.py ....................................                                                                                                                                  [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                                                                                                           [100%]

=========================================================================================== warnings summary ============================================================================================
../../miniconda_m1/envs/ska3/lib/python3.11/site-packages/tables/node.py:251: 1 warning
proseco/proseco/tests/test_acq.py: 35 warnings
proseco/proseco/tests/test_catalog.py: 52 warnings
proseco/proseco/tests/test_core.py: 17 warnings
proseco/proseco/tests/test_fid.py: 18 warnings
proseco/proseco/tests/test_guide.py: 109 warnings
proseco/proseco/tests/test_mon_full_cat.py: 5 warnings
  /Users/jean/miniconda_m1/envs/ska3/lib/python3.11/site-packages/tables/node.py:251: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    self._v_objectid = self._g_open()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 167 passed, 237 warnings in 21.53s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
