### PR TITLE
Exclude COLOR1=0.7 stars from guide selection

### DIFF
--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -148,6 +148,7 @@ def get_guide_candidates_mask(
         & (mag > 5.2)
         & (mag < faint_mag_limit)
         & (mag_err < 1.0)
+        & (stars["COLOR1"] != 0.7)
         & (stars["ASPQ1"] < 20)  # Less than 1 arcsec offset from nearby spoiler
         & (stars["ASPQ2"] == 0)  # Unknown proper motion, or PM < 500 milli-arcsec/year
         & (stars["POS_ERR"] < 1250)  # Position error < 1.25 arcsec

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -179,6 +179,22 @@ def test_bad_star_list():
     assert guides.bad_stars_mask[idx]
 
 
+def test_color1_0p7():
+    """Test that a star with COLOR1=0.7 is not selected"""
+    dark = DARK40.copy()
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(mag=np.linspace(9, 10.3, 4), n_stars=4)
+    # Bright star that would normally be selected but with color=0.7
+    bad_id = 11111111
+    stars.add_fake_star(yang=100, zang=100, mag=6.5, id=bad_id, COLOR1=0.7)
+    kwargs = mod_std_info(stars=stars, dark=dark, n_guide=5)
+    guides = get_guide_catalog(**kwargs)
+    assert bad_id not in guides["id"]
+
+    idx = guides.stars.get_id_idx(bad_id)
+    assert guides.bad_stars_mask[idx]
+
+
 def test_avoid_trap():
     """
     Set up a scenario where a star is selected fine at one roll, and then


### PR DESCRIPTION
## Description

Exclude COLOR1=0.7 stars from guide selection.

We decided to not use COLOR1=0.7 stars for guide at the [2024x09x11](https://occweb.cfa.harvard.edu/twiki/bin/view/Aspect/StarWorkingGroupMeeting2024x09x11) SS&AWG meeting.  We implemented that immediately via adding those stars to the 'bad' table in the supplement, but the idea here is that it is simpler to just add that to the mask and then remove the stars from bad table.



## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-latest) flame:proseco jean$ git rev-parse HEAD
a2f1012b84875ece373fb923e0ebed85d6f39b04
(ska3-flight-latest) flame:proseco jean$ pytest
===================================================== test session starts ======================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 168 items                                                                                                            

proseco/tests/test_acq.py .....................................                                                          [ 22%]
proseco/tests/test_catalog.py ..........................................                                                 [ 47%]
proseco/tests/test_core.py ...........................                                                                   [ 63%]
proseco/tests/test_diff.py ......                                                                                        [ 66%]
proseco/tests/test_fid.py ...............                                                                                [ 75%]
proseco/tests/test_guide.py .....................................                                                        [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                                  [100%]

===================================================== 168 passed in 24.45s
```


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I added a new unit test that fails if the COLOR1 != 0.7 filter is not applied.
