### PR TITLE
Change dyn_bgd_n_faint default to 2 and fix faint force-include bug

### DIFF
--- a/proseco/__init__.py
+++ b/proseco/__init__.py
@@ -62,7 +62,7 @@ def get_aca_catalog(*args, **kwargs):
     :param target_offset: (y, z) target offset including dynamical offset
                           (2-element sequence (y, z), deg)
     :param dyn_bgd_n_faint: number of faint stars to apply the dynamic background
-        temperature bonus ``dyn_bgd_dt_ccd`` (default=0)
+        temperature bonus ``dyn_bgd_dt_ccd`` (default=2)
     :param dyn_bgd_dt_ccd: dynamic background T_ccd temperature bonus (default=-4.0, degC)
     :param stars: table of AGASC stars (will be fetched from agasc if None)
     :param include_ids_acq: list of AGASC IDs of stars to include in acq catalog

--- a/proseco/core.py
+++ b/proseco/core.py
@@ -602,7 +602,7 @@ class ACACatalogTable(BaseCatalogTable):
     sim_offset = MetaAttribute()
     focus_offset = MetaAttribute()
     target_offset = MetaAttribute(default=(0.0, 0.0))
-    dyn_bgd_n_faint = MetaAttribute(default=0)
+    dyn_bgd_n_faint = MetaAttribute(default=2)
     dyn_bgd_dt_ccd = MetaAttribute(default=-4.0)
     stars = MetaAttribute(pickle=False)
     include_ids_acq = IntListMetaAttribute(default=[])

--- a/proseco/guide.py
+++ b/proseco/guide.py
@@ -398,7 +398,10 @@ class GuideTable(ACACatalogTable):
                 n_faint += 1
                 # If we have more than the allowed number of faint bonus stars
                 # and the star is not force-included, mark it for removal.
-                if (n_faint > self.dyn_bgd_n_faint) & (guides["stage"][idx] != 0):
+                if (
+                    n_faint > self.dyn_bgd_n_faint
+                    and guides["id"][idx] not in self.include_ids
+                ):
                     idxs_drop.append(idx)
         if idxs_drop:
             guides.remove_rows(idxs_drop)

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -66,6 +66,7 @@ def test_get_aca_catalog_20603_with_supplement():
     kwargs = dict(
         obsid=20603,
         exclude_ids_acq=[40113544],
+        dyn_bgd_n_faint=0,
         n_fid=2,
         n_guide=6,
         n_acq=7,
@@ -90,6 +91,7 @@ def test_get_aca_catalog_20603(proseco_agasc_1p7):
     aca = get_aca_catalog(
         20603,
         exclude_ids_acq=[40113544],
+        dyn_bgd_n_faint=0,
         n_fid=2,
         n_guide=6,
         n_acq=7,

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -654,7 +654,9 @@ def test_guides_include_close():
     # Force include the faint 4 stars that are also close together
     include_ids = [21, 22, 23, 24]
     cat2 = get_guide_catalog(
-        **mod_std_info(n_guide=5), stars=stars, include_ids_guide=include_ids,
+        **mod_std_info(n_guide=5),
+        stars=stars,
+        include_ids_guide=include_ids,
     )
 
     # Run the cluster checks and confirm all 3 fail
@@ -788,12 +790,16 @@ def test_guide_faint_mag_limit():
     # Select stars at 0.1 degC colder than reference temperature, use previous default of
     # dyn_bgd_n_faint=0 for this test, expect 5 stars selected
     guides = get_guide_catalog(
-        **mod_std_info(t_ccd=GUIDE.ref_faint_mag_t_ccd - 0.1, dyn_bgd_n_faint=0), stars=stars, dark=DARK40
+        **mod_std_info(t_ccd=GUIDE.ref_faint_mag_t_ccd - 0.1, dyn_bgd_n_faint=0),
+        stars=stars,
+        dark=DARK40,
     )
     assert np.all(guides["id"] == ids)
 
     # Select stars at 0.1 degC warmer than reference temperature, expect 4 stars selected
     guides = get_guide_catalog(
-        **mod_std_info(t_ccd=GUIDE.ref_faint_mag_t_ccd + 0.1, dyn_bgd_n_faint=0), stars=stars, dark=DARK40,
+        **mod_std_info(t_ccd=GUIDE.ref_faint_mag_t_ccd + 0.1, dyn_bgd_n_faint=0),
+        stars=stars,
+        dark=DARK40,
     )
     assert np.all(guides["id"] == [1, 2, 3, 4])

--- a/proseco/tests/test_guide.py
+++ b/proseco/tests/test_guide.py
@@ -654,7 +654,7 @@ def test_guides_include_close():
     # Force include the faint 4 stars that are also close together
     include_ids = [21, 22, 23, 24]
     cat2 = get_guide_catalog(
-        **mod_std_info(n_guide=5), stars=stars, include_ids_guide=include_ids
+        **mod_std_info(n_guide=5), stars=stars, include_ids_guide=include_ids,
     )
 
     # Run the cluster checks and confirm all 3 fail
@@ -785,14 +785,15 @@ def test_guide_faint_mag_limit():
         mag=[7.0] * 4 + [GUIDE.ref_faint_mag - 0.001], n_stars=5, id=ids
     )
 
-    # Select stars at 0.1 degC colder than reference temperature, expect 5 stars selected
+    # Select stars at 0.1 degC colder than reference temperature, use previous default of
+    # dyn_bgd_n_faint=0 for this test, expect 5 stars selected
     guides = get_guide_catalog(
-        **mod_std_info(t_ccd=GUIDE.ref_faint_mag_t_ccd - 0.1), stars=stars, dark=DARK40
+        **mod_std_info(t_ccd=GUIDE.ref_faint_mag_t_ccd - 0.1, dyn_bgd_n_faint=0), stars=stars, dark=DARK40
     )
     assert np.all(guides["id"] == ids)
 
     # Select stars at 0.1 degC warmer than reference temperature, expect 4 stars selected
     guides = get_guide_catalog(
-        **mod_std_info(t_ccd=GUIDE.ref_faint_mag_t_ccd + 0.1), stars=stars, dark=DARK40
+        **mod_std_info(t_ccd=GUIDE.ref_faint_mag_t_ccd + 0.1, dyn_bgd_n_faint=0), stars=stars, dark=DARK40,
     )
     assert np.all(guides["id"] == [1, 2, 3, 4])


### PR DESCRIPTION
## Description

Change the proseco dyn_bgd_n_faint default to 2. 

This had originally been left at 0 for continuity and regression testing convenience / historical compatibility, but at this point it is just confusing that the default isn't the "2" that is being used in FOT operations.

Also fixes a bug that force-included guide stars could be discarded if faint.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-latest) flame:proseco jean$ git rev-parse HEAD
0db6f1db75d727aef533c47f20bc559a02b5c663
(ska3-flight-latest) flame:proseco jean$ pytest
========================================================= test session starts ==========================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 168 items                                                                                                                    

proseco/tests/test_acq.py .....................................                                                                  [ 22%]
proseco/tests/test_catalog.py ..........................................                                                         [ 47%]
proseco/tests/test_core.py ...........................                                                                           [ 63%]
proseco/tests/test_diff.py ......                                                                                                [ 66%]
proseco/tests/test_fid.py ...............                                                                                        [ 75%]
proseco/tests/test_guide.py .....................................                                                                [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                                          [100%]

========================================================= 168 passed in 23.14s
```

Independent check of unit tests by @taldcroft:
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
test_guides_include_close is a functional test that faint force-included guide stars are included in the final catalog.