### PR TITLE
replace uses of pformat_all with pformat

### DIFF
--- a/proseco/diff.py
+++ b/proseco/diff.py
@@ -147,7 +147,7 @@ def get_catalog_lines(
 
     # Text representation of table with separator lines between GUI, MON, and
     # ACQ sections.
-    lines = out.pformat_all()
+    lines = out.pformat()
 
     # Optionally divide the fid, guide, mon, and acq sections
     if section_lines:

--- a/proseco/tests/test_catalog.py
+++ b/proseco/tests/test_catalog.py
@@ -746,7 +746,7 @@ def test_monitors_and_target_offset_args():
         "-1700.0 1900.0          2 7.5        3",
         "  500.0 -500.0          2 7.5        2",
     ]
-    assert aca.monitors.pformat_all() == exp
+    assert aca.monitors.pformat() == exp
     assert aca.target_offset is target_offset
 
 

--- a/proseco/tests/test_mon_full_cat.py
+++ b/proseco/tests/test_mon_full_cat.py
@@ -88,7 +88,7 @@ def test_monitor_mon_fixed_auto(proseco_agasc_1p7, disable_overlap_penalty):
         "   6  13    134680  ACQ 8x8  1314.00  1085.73  28   1   160",
     ]
 
-    assert aca[TEST_COLS].pformat_all() == exp
+    assert aca[TEST_COLS].pformat() == exp
     assert aca.n_guide == 4  # Two of 6 guide slots become MON slots
 
     mon = aca.get_id(1000, mon=True)
@@ -153,7 +153,7 @@ def test_full_catalog():
         "   5  11 100008  ACQ 8x8   400.00   400.00   8   1    60 10.50",
     ]
 
-    assert aca[TEST_COLS + ["mag"]].pformat_all() == exp
+    assert aca[TEST_COLS + ["mag"]].pformat() == exp
     assert aca.n_guide == 6  # One of 7 available guide slots becomes a MON
 
 
@@ -191,5 +191,5 @@ def test_mon_takes_guide():
         "   4   6 100000  ACQ 8x8  1500.00     0.00  28   1   160  6.50",
     ]
 
-    assert aca[TEST_COLS + ["mag"]].pformat_all() == exp
+    assert aca[TEST_COLS + ["mag"]].pformat() == exp
     assert aca.n_guide == 4  # One of 5 available guide slots becomes a MON


### PR DESCRIPTION
## Description

This is a change intended for skare3 > 2025.0, where we will use astropy 7.0. It replaces uses of `Table.pformat_all()` wih `Table.pformat()`. This silences a warning.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc5) ~/SAO/git/proseco pformat $ pytest proseco 
============================================================= test session starts =============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 168 items                                                                                                                           

proseco/tests/test_acq.py .....................................                                                                         [ 22%]
proseco/tests/test_catalog.py ..........................................                                                                [ 47%]
proseco/tests/test_core.py ...........................                                                                                  [ 63%]
proseco/tests/test_diff.py ......                                                                                                       [ 66%]
proseco/tests/test_fid.py ...............                                                                                               [ 75%]
proseco/tests/test_guide.py .....................................                                                                       [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                                                 [100%]

============================================================== warnings summary ===============================================================
proseco/proseco/tests/test_catalog.py::test_get_aca_catalog_49531
proseco/proseco/tests/test_catalog.py::test_get_aca_catalog_49531
  /Users/javierg/miniforge3/envs/ska3-flight-2025.0rc5/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 168 passed, 2 warnings in 27.32s =======================================================
(ska3-flight-2025.0rc5) ~/SAO/git/proseco pformat $ git rev-parse --short HEAD 
54d4c19
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
