### PR TITLE
Extrapolate ACA mag if needed for computing mag error

### DIFF
--- a/proseco/core.py
+++ b/proseco/core.py
@@ -1110,6 +1110,8 @@ get_mag_std = interp1d(
         1.0,
     ],  # std-dev
     kind="linear",
+    fill_value="extrapolate",
+    bounds_error=False,
 )
 
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,8 +1,0 @@
-{
-    "ignore": [
-        "**/node_modules",
-        "**/__pycache__",
-        "**/*.ipynb",
-        ".git"
-    ]
-}


### PR DESCRIPTION
## Description

At some point a while ago I ran into an issue with a star having mag > 20 and then scipy interpolate crashing. This change was sitting in my repo so I figured we might as well capture it.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  proseco git:(extrapolate-mags) git rev-parse --short HEAD
cc536c0
(ska3) ➜  proseco git:(extrapolate-mags) pytest 
============================================================================ test session starts ============================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 168 items                                                                                                                                                         

proseco/tests/test_acq.py .....................................                                                                                                       [ 22%]
proseco/tests/test_catalog.py ..........................................                                                                                              [ 47%]
proseco/tests/test_core.py ...........................                                                                                                                [ 63%]
proseco/tests/test_diff.py ......                                                                                                                                     [ 66%]
proseco/tests/test_fid.py ...............                                                                                                                             [ 75%]
proseco/tests/test_guide.py .....................................                                                                                                     [ 97%]
proseco/tests/test_mon_full_cat.py ....                                                                                                                               [100%]

=========================================================================== 168 passed in 33.13s ============================================================================
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
